### PR TITLE
feat: support monthly overviews

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -4,6 +4,15 @@
 
 <h1>{data.formattedDate}</h1>
 
+<ul>
+	<li>
+		<a href={data.previous.link}>{data.previous.text}</a>
+	</li>
+	<li>
+		<a href={data.next.link}>{data.next.text}</a>
+	</li>
+</ul>
+
 <h2>Expenses</h2>
 {#if data.expenses.length}
 	<ul>

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -1,0 +1,49 @@
+<script>
+	export let data;
+</script>
+
+<h1>{data.formattedDate}</h1>
+
+<h2>Expenses</h2>
+{#if data.expenses.length}
+	<ul>
+		{#each data.expenses as expense}
+			<li>{expense.description}: {expense.amount}</li>
+		{/each}
+	</ul>
+{:else}
+	<p>No expenses found.</p>
+{/if}
+
+<h2>Income</h2>
+{#if data.income.length}
+	<ul>
+		{#each data.income as incomeEntry}
+			<li>{incomeEntry.description}: {incomeEntry.amount}</li>
+		{/each}
+	</ul>
+{:else}
+	<p>No income found.</p>
+{/if}
+
+<h2>Savings</h2>
+{#if data.savings.length}
+	<ul>
+		{#each data.savings as savingsEntry}
+			<li>{savingsEntry.description}: {savingsEntry.amount}</li>
+		{/each}
+	</ul>
+{:else}
+	<p>No savings found.</p>
+{/if}
+
+<h2>Debt</h2>
+{#if data.debt.length}
+	<ul>
+		{#each data.debt as debtEntry}
+			<li>{debtEntry.description}: {debtEntry.amount}</li>
+		{/each}
+	</ul>
+{:else}
+	<p>No debt found.</p>
+{/if}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,1 +1,0 @@
-// place files you want to import through the `$lib` alias in this folder.

--- a/src/lib/monthly-overview.js
+++ b/src/lib/monthly-overview.js
@@ -1,0 +1,34 @@
+export const getMonthlyOverview = async (supabase, year, month) => {
+	const currentMonth = new Date(year, month, 1).toDateString();
+	const nextMonth = new Date(year, month + 1, 1).toDateString();
+	const { data: expenses } = await supabase
+		.from('expenses')
+		.select('id,date,category,description,amount')
+		.gte('date', currentMonth)
+		.lt('date', nextMonth);
+
+	const { data: income } = await supabase
+		.from('income')
+		.select('id,date,category,description,amount')
+		.gte('date', currentMonth)
+		.lt('date', nextMonth);
+
+	const { data: savings } = await supabase
+		.from('savings')
+		.select('id,date,category,description,amount')
+		.gte('date', currentMonth)
+		.lt('date', nextMonth);
+
+	const { data: debt } = await supabase
+		.from('debt')
+		.select('id,date,category,description,amount,interest_rate,minimum_payment')
+		.gte('date', currentMonth)
+		.lt('date', nextMonth);
+
+	return {
+		expenses,
+		income,
+		savings,
+		debt,
+	};
+};

--- a/src/lib/monthly-pagination.js
+++ b/src/lib/monthly-pagination.js
@@ -1,0 +1,33 @@
+export const getMontlyPagination = (year, month) => {
+	let previousYear = year;
+	let nextYear = year;
+	let previousMonth = month;
+	let nextMonth = month + 2;
+
+	if (previousMonth <= 0) {
+		previousYear -= 1;
+		previousMonth = 12;
+	}
+
+	if (nextMonth > 12) {
+		nextYear += 1;
+		nextMonth = 1;
+	}
+
+	return {
+		previous: {
+			link: `/overview/${previousYear}/${previousMonth}`,
+			text: new Date(previousYear, previousMonth - 1, 1).toLocaleDateString('en-US', {
+				year: 'numeric',
+				month: 'short',
+			}),
+		},
+		next: {
+			link: `/overview/${nextYear}/${nextMonth}`,
+			text: new Date(nextYear, nextMonth - 1, 1).toLocaleDateString('en-US', {
+				year: 'numeric',
+				month: 'short',
+			}),
+		},
+	};
+};

--- a/src/routes/overview/+page.server.js
+++ b/src/routes/overview/+page.server.js
@@ -1,4 +1,5 @@
 import { getMonthlyOverview } from '$lib/monthly-overview.js';
+import { getMontlyPagination } from '$lib/monthly-pagination.js';
 import { fail } from '@sveltejs/kit';
 
 export const load = async ({ locals: { supabase } }) => {
@@ -10,11 +11,14 @@ export const load = async ({ locals: { supabase } }) => {
 			year: 'numeric',
 			month: 'short',
 		});
+		const { previous, next } = getMontlyPagination(year, month);
 		const monthlyOverview = await getMonthlyOverview(supabase, year, month);
 
 		return {
 			...monthlyOverview,
 			formattedDate,
+			previous,
+			next,
 		};
 	} catch (error) {
 		return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/overview/+page.server.js
+++ b/src/routes/overview/+page.server.js
@@ -1,3 +1,4 @@
+import { getMonthlyOverview } from '$lib/monthly-overview.js';
 import { fail } from '@sveltejs/kit';
 
 export const load = async ({ locals: { supabase } }) => {
@@ -5,31 +6,15 @@ export const load = async ({ locals: { supabase } }) => {
 		const now = new Date();
 		const year = now.getFullYear();
 		const month = now.getMonth();
-		const { data: expenses } = await supabase
-			.from('expenses')
-			.select('id,date,category,description,amount')
-			.gte('date', new Date(year, month, 1).toDateString());
-
-		const { data: income } = await supabase
-			.from('income')
-			.select('id,date,category,description,amount')
-			.gte('date', new Date(year, month, 1).toDateString());
-
-		const { data: savings } = await supabase
-			.from('savings')
-			.select('id,date,category,description,amount')
-			.gte('date', new Date(year, month, 1).toDateString());
-
-		const { data: debt } = await supabase
-			.from('debt')
-			.select('id,date,category,description,amount,interest_rate,minimum_payment')
-			.gte('date', new Date(year, month, 1).toDateString());
+		const formattedDate = now.toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'short',
+		});
+		const monthlyOverview = await getMonthlyOverview(supabase, year, month);
 
 		return {
-			expenses,
-			income,
-			savings,
-			debt,
+			...monthlyOverview,
+			formattedDate,
 		};
 	} catch (error) {
 		return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/overview/+page.svelte
+++ b/src/routes/overview/+page.svelte
@@ -1,49 +1,7 @@
 <script>
+	import MonthlyOverview from '../../components/MonthlyOverview.svelte';
+
 	export let data;
 </script>
 
-<h1>Overview</h1>
-
-<h2>Expenses</h2>
-{#if data.expenses.length}
-	<ul>
-		{#each data.expenses as expense}
-			<li>{expense.description}: {expense.amount}</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No expenses found.</p>
-{/if}
-
-<h2>Income</h2>
-{#if data.income.length}
-	<ul>
-		{#each data.income as incomeEntry}
-			<li>{incomeEntry.description}: {incomeEntry.amount}</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No income found.</p>
-{/if}
-
-<h2>Savings</h2>
-{#if data.savings.length}
-	<ul>
-		{#each data.savings as savingsEntry}
-			<li>{savingsEntry.description}: {savingsEntry.amount}</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No savings found.</p>
-{/if}
-
-<h2>Debt</h2>
-{#if data.debt.length}
-	<ul>
-		{#each data.debt as debtEntry}
-			<li>{debtEntry.description}: {debtEntry.amount}</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No debt found.</p>
-{/if}
+<MonthlyOverview {data} />

--- a/src/routes/overview/[year]/[month]/+page.server.js
+++ b/src/routes/overview/[year]/[month]/+page.server.js
@@ -1,0 +1,22 @@
+import { getMonthlyOverview } from '$lib/monthly-overview.js';
+import { fail } from '@sveltejs/kit';
+
+export const load = async ({ params: { year, month }, locals: { supabase } }) => {
+	try {
+		// convert string params to numbers, offset month by one so 10 equates to October
+		const numericYear = Number(year);
+		const numericMonth = Number(month) - 1;
+		const formattedDate = new Date(numericYear, numericMonth, 1).toLocaleDateString('en-US', {
+			year: 'numeric',
+			month: 'short',
+		});
+		const monthlyOverview = await getMonthlyOverview(supabase, numericYear, numericMonth);
+
+		return {
+			...monthlyOverview,
+			formattedDate,
+		};
+	} catch (error) {
+		return fail(500, { message: 'Server error. Try again later.', success: false });
+	}
+};

--- a/src/routes/overview/[year]/[month]/+page.server.js
+++ b/src/routes/overview/[year]/[month]/+page.server.js
@@ -1,4 +1,5 @@
 import { getMonthlyOverview } from '$lib/monthly-overview.js';
+import { getMontlyPagination } from '$lib/monthly-pagination.js';
 import { fail } from '@sveltejs/kit';
 
 export const load = async ({ params: { year, month }, locals: { supabase } }) => {
@@ -10,11 +11,14 @@ export const load = async ({ params: { year, month }, locals: { supabase } }) =>
 			year: 'numeric',
 			month: 'short',
 		});
+		const { previous, next } = getMontlyPagination(numericYear, numericMonth);
 		const monthlyOverview = await getMonthlyOverview(supabase, numericYear, numericMonth);
 
 		return {
 			...monthlyOverview,
 			formattedDate,
+			previous,
+			next,
 		};
 	} catch (error) {
 		return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/overview/[year]/[month]/+page.svelte
+++ b/src/routes/overview/[year]/[month]/+page.svelte
@@ -1,0 +1,7 @@
+<script>
+	import MonthlyOverview from '../../../../components/MonthlyOverview.svelte';
+
+	export let data;
+</script>
+
+<MonthlyOverview {data} />


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This adds support for going back through previous months or going forward to future months, including basic pagination. There's a little off-by-one fuzziness because of how months are indexed at 0 for the `Date` object, but the dates as shown should match user expectations.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Navigate to your overview page and confirm the pagination shows the correct months (current one for the `h1`, then previous and next as links)
5. Click through with the pagination links, confirming relevant results come through
6. Check for the end/beginning of year cases, making sure January and December show up as expected with the correct year numbers
<!-- Add additional validation steps here -->
