### PR TITLE
feat: support deleting expenses, income, savings, and debt entries

### DIFF
--- a/src/routes/debt/[id]/+page.server.js
+++ b/src/routes/debt/[id]/+page.server.js
@@ -37,7 +37,7 @@ export const load = async ({ params: { id }, locals: { supabase } }) => {
 };
 
 export const actions = {
-	default: async ({ request, locals: { supabase } }) => {
+	edit: async ({ request, locals: { supabase } }) => {
 		const formData = await request.formData();
 		const id = formData.get('id');
 
@@ -62,6 +62,18 @@ export const actions = {
 			.from('debt')
 			.update({ date, category, description, amount, minimum_payment, interest_rate, updated_at })
 			.eq('id', id);
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/overview');
+	},
+	delete: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const id = formData.get('id');
+
+		const { error } = await supabase.from('debt').delete().eq('id', id);
 
 		if (error) {
 			return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/debt/[id]/+page.svelte
+++ b/src/routes/debt/[id]/+page.svelte
@@ -10,7 +10,7 @@
 
 <h1>Edit Debt</h1>
 
-<form method="POST">
+<form method="POST" action="?/edit">
 	<input type="hidden" name="id" value={data.debt.id} />
 	<DateInputs showDate={false} date={data.debt.date} />
 	<CategoryInput categories={data.categories} selectedCategory={data.debt.category} />
@@ -20,5 +20,6 @@
 	<InterestRateInput interestRate={data.debt.interest_rate} />
 	<div>
 		<button type="submit">Save Debt</button>
+		<button type="submit" formaction="?/delete">Delete Debt</button>
 	</div>
 </form>

--- a/src/routes/expense/[id]/+page.server.js
+++ b/src/routes/expense/[id]/+page.server.js
@@ -40,7 +40,7 @@ export const load = async ({ params: { id }, locals: { supabase } }) => {
 };
 
 export const actions = {
-	default: async ({ request, locals: { supabase } }) => {
+	edit: async ({ request, locals: { supabase } }) => {
 		const formData = await request.formData();
 		const id = formData.get('id');
 
@@ -63,6 +63,18 @@ export const actions = {
 			.from('expenses')
 			.update({ date, category, description, amount, updated_at })
 			.eq('id', id);
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/overview');
+	},
+	delete: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const id = formData.get('id');
+
+		const { error } = await supabase.from('expenses').delete().eq('id', id);
 
 		if (error) {
 			return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/expense/[id]/+page.svelte
+++ b/src/routes/expense/[id]/+page.svelte
@@ -9,7 +9,7 @@
 
 <h1>Edit Expense</h1>
 
-<form method="POST">
+<form method="POST" action="?/edit">
 	<input type="hidden" name="id" value={data.expense.id} />
 	<DateInputs date={data.expense.date} />
 	<CategoryInput categories={data.categories} selectedCategory={data.expense.category} />
@@ -17,5 +17,6 @@
 	<AmountInput amount={data.expense.amount} />
 	<div>
 		<button type="submit">Save Expense</button>
+		<button type="submit" formaction="?/delete">Delete Expense</button>
 	</div>
 </form>

--- a/src/routes/income/[id]/+page.server.js
+++ b/src/routes/income/[id]/+page.server.js
@@ -40,7 +40,7 @@ export const load = async ({ params: { id }, locals: { supabase } }) => {
 };
 
 export const actions = {
-	default: async ({ request, locals: { supabase } }) => {
+	edit: async ({ request, locals: { supabase } }) => {
 		const formData = await request.formData();
 		const id = formData.get('id');
 
@@ -63,6 +63,18 @@ export const actions = {
 			.from('income')
 			.update({ date, category, description, amount, updated_at })
 			.eq('id', id);
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/overview');
+	},
+	delete: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const id = formData.get('id');
+
+		const { error } = await supabase.from('income').delete().eq('id', id);
 
 		if (error) {
 			return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/income/[id]/+page.svelte
+++ b/src/routes/income/[id]/+page.svelte
@@ -9,7 +9,7 @@
 
 <h1>Edit Income</h1>
 
-<form method="POST">
+<form method="POST" action="?/edit">
 	<input type="hidden" name="id" value={data.income.id} />
 	<DateInputs date={data.income.date} />
 	<CategoryInput categories={data.categories} selectedCategory={data.income.category} />
@@ -17,5 +17,6 @@
 	<AmountInput amount={data.income.amount} />
 	<div>
 		<button type="submit">Save Income</button>
+		<button type="submit" formaction="?/delete">Delete Income</button>
 	</div>
 </form>

--- a/src/routes/savings/[id]/+page.server.js
+++ b/src/routes/savings/[id]/+page.server.js
@@ -40,7 +40,7 @@ export const load = async ({ params: { id }, locals: { supabase } }) => {
 };
 
 export const actions = {
-	default: async ({ request, locals: { supabase } }) => {
+	edit: async ({ request, locals: { supabase } }) => {
 		const formData = await request.formData();
 		const id = formData.get('id');
 
@@ -63,6 +63,18 @@ export const actions = {
 			.from('savings')
 			.update({ date, category, description, amount, updated_at })
 			.eq('id', id);
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/overview');
+	},
+	delete: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const id = formData.get('id');
+
+		const { error } = await supabase.from('savings').delete().eq('id', id);
 
 		if (error) {
 			return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/savings/[id]/+page.svelte
+++ b/src/routes/savings/[id]/+page.svelte
@@ -9,7 +9,7 @@
 
 <h1>Edit Savings</h1>
 
-<form method="POST">
+<form method="POST" action="?/edit">
 	<input type="hidden" name="id" value={data.savings.id} />
 	<DateInputs showDate={false} date={data.savings.date} />
 	<CategoryInput categories={data.categories} selectedCategory={data.savings.category} />
@@ -17,5 +17,6 @@
 	<AmountInput label="Balance" amount={data.savings.amount} />
 	<div>
 		<button type="submit">Save Savings</button>
+		<button type="submit" formaction="?/delete">Delete Savings</button>
 	</div>
 </form>


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This adds support for deleting records. There's no confirmation step, but since the relative effort to re-add a record is small, that's probably fine. I may come back to add a dialog-based confirmation at some point.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Navigate to the edit pages for each category and confirm they each have "Delete *" buttons that do what you'd expect
5. Confirm you can still edit entries without the deletion from happening by default
<!-- Add additional validation steps here -->
