### PR TITLE
feat: support CRUD for recurring expenses

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -25,7 +25,12 @@
 {:else}
 	<p>No expenses found.</p>
 {/if}
-<a href="/expense">Add Expense</a>
+<p>
+	<a href="/recurring-expenses">Manage Recurring Expenses</a>
+</p>
+<p>
+	<a href="/expense">Add Expense</a>
+</p>
 
 <h2>Income</h2>
 {#if data.income.length}
@@ -39,7 +44,9 @@
 {:else}
 	<p>No income found.</p>
 {/if}
-<a href="/income">Add Income</a>
+<p>
+	<a href="/income">Add Income</a>
+</p>
 
 <h2>Savings</h2>
 {#if data.savings.length}
@@ -53,7 +60,9 @@
 {:else}
 	<p>No savings found.</p>
 {/if}
-<a href="/savings">Add Savings</a>
+<p>
+	<a href="/savings">Add Savings</a>
+</p>
 
 <h2>Debt</h2>
 {#if data.debt.length}
@@ -67,4 +76,6 @@
 {:else}
 	<p>No debt found.</p>
 {/if}
-<a href="/debt">Add Debt</a>
+<p>
+	<a href="/debt">Add Debt</a>
+</p>

--- a/src/components/inputs/DateInputs.svelte
+++ b/src/components/inputs/DateInputs.svelte
@@ -1,6 +1,7 @@
 <script>
 	export let date = new Date();
 	export let showDate = true;
+	export let legend = 'Date';
 
 	let year;
 	let month;
@@ -16,7 +17,7 @@
 </script>
 
 <fieldset>
-	<legend>Date</legend>
+	<legend>{legend}</legend>
 	<div>
 		<div>
 			<label for="year">Year</label>

--- a/src/components/inputs/FrequencyInput.svelte
+++ b/src/components/inputs/FrequencyInput.svelte
@@ -3,6 +3,7 @@
 
 	export let selectedFrequency = '1-month';
 	export let daysOfMonth = [];
+	export let date;
 </script>
 
 <fieldset>
@@ -100,5 +101,5 @@
 		</div>
 	</fieldset>
 {:else}
-	<DateInputs legend="Choose the most recent date when this expense occurred" />
+	<DateInputs legend="Choose the most recent date when this expense occurred" {date} />
 {/if}

--- a/src/components/inputs/FrequencyInput.svelte
+++ b/src/components/inputs/FrequencyInput.svelte
@@ -1,0 +1,104 @@
+<script>
+	import DateInputs from './DateInputs.svelte';
+
+	export let selectedFrequency = '1-month';
+	export let daysOfMonth = [];
+</script>
+
+<fieldset>
+	<legend>Frequency</legend>
+	<div>
+		<div>
+			<input
+				id="frequency__1-month"
+				type="radio"
+				name="frequency"
+				value="1-month"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__1-month">Every Month</label>
+		</div>
+		<div>
+			<input
+				id="frequency__3-month"
+				type="radio"
+				name="frequency"
+				value="3-month"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__3-month">Every 3 Months</label>
+		</div>
+		<div>
+			<input
+				id="frequency__6-month"
+				type="radio"
+				name="frequency"
+				value="6-month"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__6-month">Every 6 Months</label>
+		</div>
+		<div>
+			<input
+				id="frequency__1-year"
+				type="radio"
+				name="frequency"
+				value="1-year"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__1-year">Every Year</label>
+		</div>
+		<div>
+			<input
+				id="frequency__1-week"
+				type="radio"
+				name="frequency"
+				value="1-week"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__1-week">Every Week</label>
+		</div>
+		<div>
+			<input
+				id="frequency__2-week"
+				type="radio"
+				name="frequency"
+				value="2-week"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__2-week">Every 2 Weeks</label>
+		</div>
+		<div>
+			<input
+				id="frequency__twice-per-month"
+				type="radio"
+				name="frequency"
+				value="twice-per-month"
+				bind:group={selectedFrequency}
+			/>
+			<label for="frequency__twice-per-month">Twice per Month</label>
+		</div>
+	</div>
+</fieldset>
+
+{#if selectedFrequency === 'twice-per-month'}
+	<fieldset>
+		<legend>Choose which days of the month this expense typically occurs on</legend>
+		<div>
+			{#each Array(31) as day, index}
+				<div>
+					<input
+						id="day__{index + 1}"
+						type="checkbox"
+						name="days-of-month"
+						value={index + 1}
+						bind:group={daysOfMonth}
+					/>
+					<label for="day__{index + 1}">{index + 1}</label>
+				</div>
+			{/each}
+		</div>
+	</fieldset>
+{:else}
+	<DateInputs legend="Choose the most recent date when this expense occurred" />
+{/if}

--- a/src/components/inputs/FrequencyInput.svelte
+++ b/src/components/inputs/FrequencyInput.svelte
@@ -86,6 +86,7 @@
 	<fieldset>
 		<legend>Choose which days of the month this expense typically occurs on</legend>
 		<div>
+			<!-- eslint-disable-next-line no-unused-vars -->
 			{#each Array(31) as day, index}
 				<div>
 					<input

--- a/src/components/inputs/IsActiveInput.svelte
+++ b/src/components/inputs/IsActiveInput.svelte
@@ -1,0 +1,8 @@
+<script>
+	export let isActive = false;
+</script>
+
+<div>
+	<input id="is-active" type="checkbox" name="active" checked={isActive} />
+	<label for="is-active">This is currently active</label>
+</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,10 +22,11 @@
 
 <header>
 	<nav>
-		<a href="/">Home</a>
 		{#if session != null}
+			<a href="/overview">Overview</a>
 			<a href="/auth/sign-out">Sign out</a>
 		{:else}
+			<a href="/">Home</a>
 			<a href="/auth/login">Log in/sign up</a>
 		{/if}
 	</nav>

--- a/src/routes/recurring-expenses/+page.server.js
+++ b/src/routes/recurring-expenses/+page.server.js
@@ -1,0 +1,11 @@
+export const load = async ({ locals: { supabase } }) => {
+	const { data: recurringExpenses } = await supabase
+		.from('recurring_expenses')
+		.select('id,date,description,amount,frequency,active')
+		.order('active', { ascending: false })
+		.order('amount', { ascending: false });
+
+	return {
+		recurringExpenses,
+	};
+};

--- a/src/routes/recurring-expenses/+page.svelte
+++ b/src/routes/recurring-expenses/+page.svelte
@@ -8,7 +8,9 @@
 	<ul>
 		{#each data.recurringExpenses as expense}
 			<li>
-				{expense.description}: {expense.amount}
+				<a href="/recurring-expenses/expense/{expense.id}"
+					>{expense.description}: {expense.amount}</a
+				>
 			</li>
 		{/each}
 	</ul>

--- a/src/routes/recurring-expenses/+page.svelte
+++ b/src/routes/recurring-expenses/+page.svelte
@@ -15,3 +15,6 @@
 {:else}
 	<p>No recurring expenses found.</p>
 {/if}
+<p>
+	<a href="/recurring-expenses/expense">Add Recurring Expense</a>
+</p>

--- a/src/routes/recurring-expenses/+page.svelte
+++ b/src/routes/recurring-expenses/+page.svelte
@@ -1,0 +1,17 @@
+<script>
+	export let data;
+</script>
+
+<h1>Recurring Expenses</h1>
+
+{#if data.recurringExpenses.length}
+	<ul>
+		{#each data.recurringExpenses as expense}
+			<li>
+				{expense.description}: {expense.amount}
+			</li>
+		{/each}
+	</ul>
+{:else}
+	<p>No recurring expenses found.</p>
+{/if}

--- a/src/routes/recurring-expenses/expense/+page.server.js
+++ b/src/routes/recurring-expenses/expense/+page.server.js
@@ -1,0 +1,60 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { formatAmount, formatDate } from '$lib/format-inputs.js';
+
+export const load = async ({ locals: { supabase } }) => {
+	try {
+		const { data: categories } = await supabase
+			.from('expense_categories')
+			.select('category')
+			.order('category');
+
+		return {
+			categories,
+		};
+	} catch (error) {
+		return fail(500, { message: 'Server error. Try again later.', success: false });
+	}
+};
+
+export const actions = {
+	default: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const amount = formatAmount(formData.get('amount'));
+
+		const selectedCategory = formData.get('category');
+		const newCategory = formData.get('new-category');
+		const category = newCategory ?? selectedCategory;
+
+		const description = formData.get('description') || category;
+
+		const now = new Date();
+		const year = formData.get('year') ?? now.getFullYear();
+		const month = formData.get('month') ?? now.getMonth() + 1;
+		const day = formData.get('day') ?? now.getDate();
+		const date = formatDate(year, month, day);
+
+		const frequency = formData.get('frequency');
+		const days_of_month = formData.getAll('days-of-month') ?? [];
+		const active = !!formData.get('active');
+
+		const {
+			data: { user },
+		} = await supabase.auth.getUser();
+		const { error } = await supabase.from('recurring_expenses').insert({
+			user_id: user.id,
+			date,
+			category,
+			description,
+			amount,
+			frequency,
+			days_of_month,
+			active,
+		});
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/recurring-expenses');
+	},
+};

--- a/src/routes/recurring-expenses/expense/+page.svelte
+++ b/src/routes/recurring-expenses/expense/+page.svelte
@@ -1,0 +1,22 @@
+<script>
+	import AmountInput from '../../../components/inputs/AmountInput.svelte';
+	import CategoryInput from '../../../components/inputs/CategoryInput.svelte';
+	import DescriptionInput from '../../../components/inputs/DescriptionInput.svelte';
+	import FrequencyInput from '../../../components/inputs/FrequencyInput.svelte';
+	import IsActiveInput from '../../../components/inputs/IsActiveInput.svelte';
+
+	export let data;
+</script>
+
+<h1>Add Recurring Expense</h1>
+
+<form method="POST">
+	<CategoryInput categories={data.categories} />
+	<DescriptionInput />
+	<AmountInput />
+	<FrequencyInput />
+	<IsActiveInput />
+	<div>
+		<button type="submit">Save Recurring Expense</button>
+	</div>
+</form>

--- a/src/routes/recurring-expenses/expense/[id]/+page.server.js
+++ b/src/routes/recurring-expenses/expense/[id]/+page.server.js
@@ -40,7 +40,7 @@ export const load = async ({ params: { id }, locals: { supabase } }) => {
 };
 
 export const actions = {
-	default: async ({ request, locals: { supabase } }) => {
+	edit: async ({ request, locals: { supabase } }) => {
 		const formData = await request.formData();
 		const id = formData.get('id');
 
@@ -77,6 +77,18 @@ export const actions = {
 				updated_at,
 			})
 			.eq('id', id);
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/recurring-expenses');
+	},
+	delete: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const id = formData.get('id');
+
+		const { error } = await supabase.from('recurring_expenses').delete().eq('id', id);
 
 		if (error) {
 			return fail(500, { message: 'Server error. Try again later.', success: false });

--- a/src/routes/recurring-expenses/expense/[id]/+page.server.js
+++ b/src/routes/recurring-expenses/expense/[id]/+page.server.js
@@ -1,0 +1,87 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { formatAmount, formatDate } from '$lib/format-inputs.js';
+
+const getCategories = async (supabase) => {
+	const { data: categories } = await supabase
+		.from('expense_categories')
+		.select('category')
+		.order('category');
+
+	return categories;
+};
+
+const getExpense = async (supabase, id) => {
+	const { data: expense } = await supabase
+		.from('recurring_expenses')
+		.select('id,date,category,description,amount,frequency,days_of_month,active')
+		.eq('id', id);
+
+	if (!expense?.[0]) {
+		throw new Error('Could not find the specified expense.');
+	}
+
+	return expense[0];
+};
+
+export const load = async ({ params: { id }, locals: { supabase } }) => {
+	try {
+		const [categories, expense] = await Promise.all([
+			getCategories(supabase),
+			getExpense(supabase, id),
+		]);
+
+		return {
+			categories,
+			expense,
+		};
+	} catch (error) {
+		return fail(500, { message: 'Server error. Try again later.', success: false });
+	}
+};
+
+export const actions = {
+	default: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const id = formData.get('id');
+
+		const amount = formatAmount(formData.get('amount'));
+
+		const selectedCategory = formData.get('category');
+		const newCategory = formData.get('new-category');
+		const category = newCategory ?? selectedCategory;
+
+		const description = formData.get('description') || category;
+
+		const now = new Date();
+		const year = formData.get('year') ?? now.getFullYear();
+		const month = formData.get('month') ?? now.getMonth() + 1;
+		const day = formData.get('day') ?? now.getDate();
+		const date = formatDate(year, month, day);
+
+		const frequency = formData.get('frequency');
+		const days_of_month = formData.getAll('days-of-month') ?? [];
+		const active = !!formData.get('active');
+
+		const updated_at = new Date();
+
+		const { error } = await supabase
+			.from('recurring_expenses')
+			.update({
+				date,
+				category,
+				description,
+				amount,
+				frequency,
+				days_of_month,
+				active,
+				updated_at,
+			})
+			.eq('id', id);
+
+		if (error) {
+			return fail(500, { message: 'Server error. Try again later.', success: false });
+		}
+
+		throw redirect(303, '/recurring-expenses');
+	},
+};

--- a/src/routes/recurring-expenses/expense/[id]/+page.svelte
+++ b/src/routes/recurring-expenses/expense/[id]/+page.svelte
@@ -10,7 +10,7 @@
 
 <h1>Edit Recurring Expense</h1>
 
-<form method="POST">
+<form method="POST" action="?/edit">
 	<input type="hidden" name="id" value={data.expense.id} />
 	<CategoryInput categories={data.categories} selectedCategory={data.expense.category} />
 	<DescriptionInput description={data.expense.description} />
@@ -23,5 +23,6 @@
 	<IsActiveInput isActive={data.expense.active} />
 	<div>
 		<button type="submit">Save Recurring Expense</button>
+		<button type="submit" formaction="?/delete">Delete Recurring Expense</button>
 	</div>
 </form>

--- a/src/routes/recurring-expenses/expense/[id]/+page.svelte
+++ b/src/routes/recurring-expenses/expense/[id]/+page.svelte
@@ -1,0 +1,27 @@
+<script>
+	import AmountInput from '../../../../components/inputs/AmountInput.svelte';
+	import CategoryInput from '../../../../components/inputs/CategoryInput.svelte';
+	import DescriptionInput from '../../../../components/inputs/DescriptionInput.svelte';
+	import FrequencyInput from '../../../../components/inputs/FrequencyInput.svelte';
+	import IsActiveInput from '../../../../components/inputs/IsActiveInput.svelte';
+
+	export let data;
+</script>
+
+<h1>Edit Recurring Expense</h1>
+
+<form method="POST">
+	<input type="hidden" name="id" value={data.expense.id} />
+	<CategoryInput categories={data.categories} selectedCategory={data.expense.category} />
+	<DescriptionInput description={data.expense.description} />
+	<AmountInput amount={data.expense.amount} />
+	<FrequencyInput
+		selectedFrequency={data.expense.frequency}
+		daysOfMonth={data.expense.days_of_month}
+		date={data.expense.date}
+	/>
+	<IsActiveInput isActive={data.expense.active} />
+	<div>
+		<button type="submit">Save Recurring Expense</button>
+	</div>
+</form>


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This implements support for recurring expenses, except for the part where they are copied to a new month. This is all CRUD for getting the recurring expenses set up in the DB.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Click "Manage Recurring Expenses" from the overview page and confirm it lists the existing expenses
5. Check that you can add, edit, and delete recurring expenses as expected
<!-- Add additional validation steps here -->
