### PR TITLE
feat: gate dynamic pages for unauthenticated users

### DIFF
--- a/src/lib/gate-dynamic-page.js
+++ b/src/lib/gate-dynamic-page.js
@@ -1,0 +1,11 @@
+import { redirect } from '@sveltejs/kit';
+
+export const gateDynamicPage = async (supabase) => {
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (user == null) {
+		throw redirect(303, '/');
+	}
+};

--- a/src/routes/auth/confirm/+page.svelte
+++ b/src/routes/auth/confirm/+page.svelte
@@ -1,13 +1,24 @@
 <script>
 	export let data;
+
+	let { session } = data;
 </script>
 
 <h1>Confirm Login</h1>
-<p>Check your email for a one-time code that you can use to confirm your login.</p>
 
-<form method="POST">
-	<input type="hidden" name="email" value={data.email} />
-	<label for="token">One-time code</label>
-	<input id="token" type="text" name="token" inputmode="numeric" autocomplete="one-time-code" />
-	<button type="submit">Finish logging in</button>
-</form>
+{#if session?.user?.email != null}
+	<p>
+		You are already logged in as <em>{session.user.email}</em>.
+		<a href="/auth/sign-out">Sign out</a>
+		to change accounts, or go back to your <a href="/overview">overview page</a>.
+	</p>
+{:else}
+	<p>Check your email for a one-time code that you can use to confirm your login.</p>
+
+	<form method="POST">
+		<input type="hidden" name="email" value={data.email} />
+		<label for="token">One-time code</label>
+		<input id="token" type="text" name="token" inputmode="numeric" autocomplete="one-time-code" />
+		<button type="submit">Finish logging in</button>
+	</form>
+{/if}

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,11 +1,26 @@
-<h1>Log in or sign up</h1>
-<p>
-	We will send you an email with a link that you can use to finish logging in. If you don't have an
-	account already, one will be created automatically.
-</p>
+<script>
+	export let data;
 
-<form method="POST">
-	<label for="email">Email</label>
-	<input id="email" type="email" name="email" autocomplete="email" />
-	<button type="submit">Request link</button>
-</form>
+	let { session } = data;
+</script>
+
+<h1>Log in or sign up</h1>
+
+{#if session?.user?.email != null}
+	<p>
+		You are already logged in as <em>{session.user.email}</em>.
+		<a href="/auth/sign-out">Sign out</a>
+		to change accounts, or go back to your <a href="/overview">overview page</a>.
+	</p>
+{:else}
+	<p>
+		We will send you an email with a link that you can use to finish logging in. If you don't have
+		an account already, one will be created automatically.
+	</p>
+
+	<form method="POST">
+		<label for="email">Email</label>
+		<input id="email" type="email" name="email" autocomplete="email" />
+		<button type="submit">Request link</button>
+	</form>
+{/if}

--- a/src/routes/debt/+page.server.js
+++ b/src/routes/debt/+page.server.js
@@ -1,19 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const { data: categories } = await supabase
-			.from('debt_categories')
-			.select('category')
-			.order('category');
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const { data: categories } = await supabase
+		.from('debt_categories')
+		.select('category')
+		.order('category');
+
+	return {
+		categories,
+	};
 };
 
 export const actions = {

--- a/src/routes/debt/[id]/+page.server.js
+++ b/src/routes/debt/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 const getCategories = async (supabase) => {
 	const { data: categories } = await supabase
@@ -24,16 +25,14 @@ const getDebt = async (supabase, id) => {
 };
 
 export const load = async ({ params: { id }, locals: { supabase } }) => {
-	try {
-		const [categories, debt] = await Promise.all([getCategories(supabase), getDebt(supabase, id)]);
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-			debt,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const [categories, debt] = await Promise.all([getCategories(supabase), getDebt(supabase, id)]);
+
+	return {
+		categories,
+		debt,
+	};
 };
 
 export const actions = {

--- a/src/routes/expense/+page.server.js
+++ b/src/routes/expense/+page.server.js
@@ -1,19 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const { data: categories } = await supabase
-			.from('expense_categories')
-			.select('category')
-			.order('category');
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const { data: categories } = await supabase
+		.from('expense_categories')
+		.select('category')
+		.order('category');
+
+	return {
+		categories,
+	};
 };
 
 export const actions = {

--- a/src/routes/expense/[id]/+page.server.js
+++ b/src/routes/expense/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 const getCategories = async (supabase) => {
 	const { data: categories } = await supabase
@@ -24,19 +25,17 @@ const getExpense = async (supabase, id) => {
 };
 
 export const load = async ({ params: { id }, locals: { supabase } }) => {
-	try {
-		const [categories, expense] = await Promise.all([
-			getCategories(supabase),
-			getExpense(supabase, id),
-		]);
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-			expense,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const [categories, expense] = await Promise.all([
+		getCategories(supabase),
+		getExpense(supabase, id),
+	]);
+
+	return {
+		categories,
+		expense,
+	};
 };
 
 export const actions = {

--- a/src/routes/income/+page.server.js
+++ b/src/routes/income/+page.server.js
@@ -1,19 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const { data: categories } = await supabase
-			.from('income_categories')
-			.select('category')
-			.order('category');
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const { data: categories } = await supabase
+		.from('income_categories')
+		.select('category')
+		.order('category');
+
+	return {
+		categories,
+	};
 };
 
 export const actions = {

--- a/src/routes/income/[id]/+page.server.js
+++ b/src/routes/income/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 const getCategories = async (supabase) => {
 	const { data: categories } = await supabase
@@ -24,19 +25,17 @@ const getIncome = async (supabase, id) => {
 };
 
 export const load = async ({ params: { id }, locals: { supabase } }) => {
-	try {
-		const [categories, income] = await Promise.all([
-			getCategories(supabase),
-			getIncome(supabase, id),
-		]);
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-			income,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const [categories, income] = await Promise.all([
+		getCategories(supabase),
+		getIncome(supabase, id),
+	]);
+
+	return {
+		categories,
+		income,
+	};
 };
 
 export const actions = {

--- a/src/routes/overview/+page.server.js
+++ b/src/routes/overview/+page.server.js
@@ -1,26 +1,23 @@
 import { getMonthlyOverview } from '$lib/monthly-overview.js';
 import { getMontlyPagination } from '$lib/monthly-pagination.js';
-import { fail } from '@sveltejs/kit';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const now = new Date();
-		const year = now.getFullYear();
-		const month = now.getMonth();
-		const formattedDate = now.toLocaleDateString('en-US', {
-			year: 'numeric',
-			month: 'short',
-		});
-		const { previous, next } = getMontlyPagination(year, month);
-		const monthlyOverview = await getMonthlyOverview(supabase, year, month);
+	await gateDynamicPage(supabase);
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = now.getMonth();
+	const formattedDate = now.toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'short',
+	});
+	const { previous, next } = getMontlyPagination(year, month);
+	const monthlyOverview = await getMonthlyOverview(supabase, year, month);
 
-		return {
-			...monthlyOverview,
-			formattedDate,
-			previous,
-			next,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	return {
+		...monthlyOverview,
+		formattedDate,
+		previous,
+		next,
+	};
 };

--- a/src/routes/overview/[year]/[month]/+page.server.js
+++ b/src/routes/overview/[year]/[month]/+page.server.js
@@ -1,26 +1,24 @@
 import { getMonthlyOverview } from '$lib/monthly-overview.js';
 import { getMontlyPagination } from '$lib/monthly-pagination.js';
-import { fail } from '@sveltejs/kit';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ params: { year, month }, locals: { supabase } }) => {
-	try {
-		// convert string params to numbers, offset month by one so 10 equates to October
-		const numericYear = Number(year);
-		const numericMonth = Number(month) - 1;
-		const formattedDate = new Date(numericYear, numericMonth, 1).toLocaleDateString('en-US', {
-			year: 'numeric',
-			month: 'short',
-		});
-		const { previous, next } = getMontlyPagination(numericYear, numericMonth);
-		const monthlyOverview = await getMonthlyOverview(supabase, numericYear, numericMonth);
+	await gateDynamicPage(supabase);
 
-		return {
-			...monthlyOverview,
-			formattedDate,
-			previous,
-			next,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	// convert string params to numbers, offset month by one so 10 equates to October
+	const numericYear = Number(year);
+	const numericMonth = Number(month) - 1;
+	const formattedDate = new Date(numericYear, numericMonth, 1).toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'short',
+	});
+	const { previous, next } = getMontlyPagination(numericYear, numericMonth);
+	const monthlyOverview = await getMonthlyOverview(supabase, numericYear, numericMonth);
+
+	return {
+		...monthlyOverview,
+		formattedDate,
+		previous,
+		next,
+	};
 };

--- a/src/routes/recurring-expenses/+page.server.js
+++ b/src/routes/recurring-expenses/+page.server.js
@@ -1,4 +1,8 @@
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
+
 export const load = async ({ locals: { supabase } }) => {
+	await gateDynamicPage(supabase);
+
 	const { data: recurringExpenses } = await supabase
 		.from('recurring_expenses')
 		.select('id,date,description,amount,frequency,active')

--- a/src/routes/recurring-expenses/expense/+page.server.js
+++ b/src/routes/recurring-expenses/expense/+page.server.js
@@ -1,19 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const { data: categories } = await supabase
-			.from('expense_categories')
-			.select('category')
-			.order('category');
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const { data: categories } = await supabase
+		.from('expense_categories')
+		.select('category')
+		.order('category');
+
+	return {
+		categories,
+	};
 };
 
 export const actions = {

--- a/src/routes/recurring-expenses/expense/[id]/+page.server.js
+++ b/src/routes/recurring-expenses/expense/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 const getCategories = async (supabase) => {
 	const { data: categories } = await supabase
@@ -24,19 +25,17 @@ const getExpense = async (supabase, id) => {
 };
 
 export const load = async ({ params: { id }, locals: { supabase } }) => {
-	try {
-		const [categories, expense] = await Promise.all([
-			getCategories(supabase),
-			getExpense(supabase, id),
-		]);
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-			expense,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const [categories, expense] = await Promise.all([
+		getCategories(supabase),
+		getExpense(supabase, id),
+	]);
+
+	return {
+		categories,
+		expense,
+	};
 };
 
 export const actions = {

--- a/src/routes/recurring-income/+page.server.js
+++ b/src/routes/recurring-income/+page.server.js
@@ -1,4 +1,8 @@
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
+
 export const load = async ({ locals: { supabase } }) => {
+	await gateDynamicPage(supabase);
+
 	const { data: recurringIncome } = await supabase
 		.from('recurring_income')
 		.select('id,date,description,amount,frequency,active')

--- a/src/routes/recurring-income/income/+page.server.js
+++ b/src/routes/recurring-income/income/+page.server.js
@@ -1,19 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const { data: categories } = await supabase
-			.from('income_categories')
-			.select('category')
-			.order('category');
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const { data: categories } = await supabase
+		.from('income_categories')
+		.select('category')
+		.order('category');
+
+	return {
+		categories,
+	};
 };
 
 export const actions = {

--- a/src/routes/recurring-income/income/[id]/+page.server.js
+++ b/src/routes/recurring-income/income/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 const getCategories = async (supabase) => {
 	const { data: categories } = await supabase
@@ -24,19 +25,17 @@ const getIncome = async (supabase, id) => {
 };
 
 export const load = async ({ params: { id }, locals: { supabase } }) => {
-	try {
-		const [categories, income] = await Promise.all([
-			getCategories(supabase),
-			getIncome(supabase, id),
-		]);
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-			income,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const [categories, income] = await Promise.all([
+		getCategories(supabase),
+		getIncome(supabase, id),
+	]);
+
+	return {
+		categories,
+		income,
+	};
 };
 
 export const actions = {

--- a/src/routes/savings/+page.server.js
+++ b/src/routes/savings/+page.server.js
@@ -1,19 +1,18 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 export const load = async ({ locals: { supabase } }) => {
-	try {
-		const { data: categories } = await supabase
-			.from('savings_categories')
-			.select('category')
-			.order('category');
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const { data: categories } = await supabase
+		.from('savings_categories')
+		.select('category')
+		.order('category');
+
+	return {
+		categories,
+	};
 };
 
 export const actions = {

--- a/src/routes/savings/[id]/+page.server.js
+++ b/src/routes/savings/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { formatAmount, formatDate } from '$lib/format-inputs.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
 const getCategories = async (supabase) => {
 	const { data: categories } = await supabase
@@ -24,19 +25,17 @@ const getSavings = async (supabase, id) => {
 };
 
 export const load = async ({ params: { id }, locals: { supabase } }) => {
-	try {
-		const [categories, savings] = await Promise.all([
-			getCategories(supabase),
-			getSavings(supabase, id),
-		]);
+	await gateDynamicPage(supabase);
 
-		return {
-			categories,
-			savings,
-		};
-	} catch (error) {
-		return fail(500, { message: 'Server error. Try again later.', success: false });
-	}
+	const [categories, savings] = await Promise.all([
+		getCategories(supabase),
+		getSavings(supabase, id),
+	]);
+
+	return {
+		categories,
+		savings,
+	};
 };
 
 export const actions = {


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This work prevents anonymous users from accessing pages that require authentication to be useful. They'll be redirected to the home page, which should eventually have useful call-to-action stuff. For the login and login confirmation pages, this does sort of the opposite, making it so already authenticated users can't re-submit login forms.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Log out and try to get to the dynamic pages, confirming that you just land on the home page
5. Log in, then try to go to the `/auth/login` and `/auth/confirm` pages, confirming you get a "go away" message
<!-- Add additional validation steps here -->
