### PR TITLE
feat: support copying recurring expenses

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -1,8 +1,21 @@
 <script>
 	export let data;
+
+	let {
+		year,
+		month,
+		formattedDate,
+		previous,
+		next,
+		expenses,
+		income,
+		savings,
+		debt,
+		canCopyExpenses,
+	} = data;
 </script>
 
-<h1>{data.formattedDate}</h1>
+<h1>{formattedDate}</h1>
 
 <ul>
 	<li>
@@ -14,9 +27,9 @@
 </ul>
 
 <h2>Expenses</h2>
-{#if data.expenses.length}
+{#if expenses.length}
 	<ul>
-		{#each data.expenses as expense}
+		{#each expenses as expense}
 			<li>
 				<a href="/expense/{expense.id}">{expense.description}: {expense.amount}</a>
 			</li>
@@ -24,6 +37,13 @@
 	</ul>
 {:else}
 	<p>No expenses found.</p>
+	{#if canCopyExpenses}
+		<form method="POST" action="?/copyExpenses">
+			<input type="hidden" name="year" value={year} />
+			<input type="hidden" name="month" value={month} />
+			<button type="submit">Copy Recurring Expenses</button>
+		</form>
+	{/if}
 {/if}
 <p>
 	<a href="/recurring-expenses">Manage Recurring Expenses</a>
@@ -33,9 +53,9 @@
 </p>
 
 <h2>Income</h2>
-{#if data.income.length}
+{#if income.length}
 	<ul>
-		{#each data.income as incomeEntry}
+		{#each income as incomeEntry}
 			<li>
 				<a href="/income/{incomeEntry.id}">{incomeEntry.description}: {incomeEntry.amount}</a>
 			</li>
@@ -52,9 +72,9 @@
 </p>
 
 <h2>Savings</h2>
-{#if data.savings.length}
+{#if savings.length}
 	<ul>
-		{#each data.savings as savingsEntry}
+		{#each savings as savingsEntry}
 			<li>
 				<a href="/savings/{savingsEntry.id}">{savingsEntry.description}: {savingsEntry.amount}</a>
 			</li>
@@ -68,9 +88,9 @@
 </p>
 
 <h2>Debt</h2>
-{#if data.debt.length}
+{#if debt.length}
 	<ul>
-		{#each data.debt as debtEntry}
+		{#each debt as debtEntry}
 			<li>
 				<a href="/debt/{debtEntry.id}">{debtEntry.description}: {debtEntry.amount}</a>
 			</li>

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -6,10 +6,10 @@
 
 <ul>
 	<li>
-		<a href={data.previous.link}>{data.previous.text}</a>
+		<a href={previous.link} data-sveltekit-reload>{previous.text}</a>
 	</li>
 	<li>
-		<a href={data.next.link}>{data.next.text}</a>
+		<a href={next.link} data-sveltekit-reload>{next.text}</a>
 	</li>
 </ul>
 

--- a/src/lib/copy-recurring.js
+++ b/src/lib/copy-recurring.js
@@ -1,0 +1,149 @@
+import { redirect } from '@sveltejs/kit';
+
+const setToCurrentMonth = (year, month, day) => {
+	let date = new Date(year, month, day);
+
+	// not enough days in month, go back one or more days
+	while (date.getMonth() > month) {
+		date.setDate(date.getDate() - 1);
+	}
+
+	return date;
+};
+
+const addExpense = async (supabase, expense) => {
+	const { error } = await supabase.from('expenses').insert(expense);
+
+	if (error) {
+		throw new Error(error);
+	}
+};
+
+export const actions = {
+	copyExpenses: async ({ request, url: { pathname }, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const year = formData.get('year');
+		const month = formData.get('month');
+
+		const numericYear = Number(year);
+		const numericMonth = Number(month);
+
+		const currentMonth = new Date(numericYear, numericMonth, 1);
+		const nextMonth = new Date(numericYear, numericMonth + 1, 1);
+
+		const { data: recurringExpenses } = await supabase
+			.from('recurring_expenses')
+			.select('user_id,date,category,description,amount,frequency,days_of_month')
+			.eq('active', true);
+
+		const newExpenses = [];
+
+		for (const expense of recurringExpenses) {
+			const originalDate = new Date(expense.date);
+			const originalDateMonth = originalDate.getUTCMonth();
+			const originalDateDay = originalDate.getUTCDate();
+
+			switch (expense.frequency) {
+				case '1-month': {
+					const newExpense = {
+						...expense,
+						date: setToCurrentMonth(numericYear, numericMonth, originalDateDay),
+					};
+					delete newExpense.frequency;
+					delete newExpense.days_of_month;
+					newExpenses.push(newExpense);
+					break;
+				}
+				case '3-month': {
+					if (Math.abs(numericMonth - originalDateMonth) % 3 === 0) {
+						const newExpense = {
+							...expense,
+							date: setToCurrentMonth(numericYear, numericMonth, originalDateDay),
+						};
+						delete newExpense.frequency;
+						delete newExpense.days_of_month;
+						newExpenses.push(newExpense);
+					}
+					break;
+				}
+				case '6-month': {
+					if (Math.abs(numericMonth - originalDateMonth) % 6 === 0) {
+						const newExpense = {
+							...expense,
+							date: setToCurrentMonth(numericYear, numericMonth, originalDateDay),
+						};
+						delete newExpense.frequency;
+						delete newExpense.days_of_month;
+						newExpenses.push(newExpense);
+					}
+					break;
+				}
+				case '1-year': {
+					if (numericMonth === originalDateMonth) {
+						const newExpense = {
+							...expense,
+							date: setToCurrentMonth(numericYear, numericMonth, originalDateDay),
+						};
+						delete newExpense.frequency;
+						delete newExpense.days_of_month;
+						newExpenses.push(newExpense);
+					}
+					break;
+				}
+				case '1-week': {
+					const gapInDays = Math.floor((currentMonth - originalDate) / 1000 / 3600 / 24);
+					const offset = 7 - (gapInDays % 7);
+					let newExpenseDate = new Date(numericYear, numericMonth, 1 + offset);
+
+					while (newExpenseDate < nextMonth) {
+						const newExpense = {
+							...expense,
+							date: new Date(newExpenseDate),
+						};
+						delete newExpense.frequency;
+						delete newExpense.days_of_month;
+						newExpenses.push(newExpense);
+						newExpenseDate.setDate(newExpenseDate.getDate() + 7);
+					}
+					break;
+				}
+				case '2-week': {
+					const gapInDays = Math.floor((currentMonth - originalDate) / 1000 / 3600 / 24);
+					const offset = 14 - (gapInDays % 14);
+					let newExpenseDate = new Date(numericYear, numericMonth, 1 + offset);
+
+					while (newExpenseDate < nextMonth) {
+						const newExpense = {
+							...expense,
+							date: new Date(newExpenseDate),
+						};
+						delete newExpense.frequency;
+						delete newExpense.days_of_month;
+						newExpenses.push(newExpense);
+						newExpenseDate.setDate(newExpenseDate.getDate() + 14);
+					}
+					break;
+				}
+				case 'twice-per-month': {
+					for (const day of expense.days_of_month) {
+						const newExpense = {
+							...expense,
+							date: setToCurrentMonth(numericYear, numericMonth, day),
+						};
+						delete newExpense.frequency;
+						delete newExpense.days_of_month;
+						newExpenses.push(newExpense);
+					}
+					break;
+				}
+				default: {
+					break;
+				}
+			}
+		}
+
+		await Promise.all(newExpenses.map((expense) => addExpense(supabase, expense)));
+
+		throw redirect(303, pathname);
+	},
+};

--- a/src/lib/monthly-overview.js
+++ b/src/lib/monthly-overview.js
@@ -38,20 +38,33 @@ const getDebt = async (supabase, currentMonth, nextMonth) => {
 	return debt;
 };
 
+const hasRecurringExpenses = async (supabase) => {
+	const { count } = await supabase
+		.from('recurring_expenses')
+		.select('*', { count: 'exact', head: true })
+		.eq('active', true);
+
+	return count > 0;
+};
+
 export const getMonthlyOverview = async (supabase, year, month) => {
 	const currentMonth = new Date(year, month, 1).toDateString();
 	const nextMonth = new Date(year, month + 1, 1).toDateString();
-	const [expenses, income, savings, debt] = await Promise.all([
+	const [expenses, income, savings, debt, canCopyExpenses] = await Promise.all([
 		getExpenses(supabase, currentMonth, nextMonth),
 		getIncome(supabase, currentMonth, nextMonth),
 		getSavings(supabase, currentMonth, nextMonth),
 		getDebt(supabase, currentMonth, nextMonth),
+		hasRecurringExpenses(supabase),
 	]);
 
 	return {
+		year,
+		month,
 		expenses,
 		income,
 		savings,
 		debt,
+		canCopyExpenses,
 	};
 };

--- a/src/routes/overview/+page.server.js
+++ b/src/routes/overview/+page.server.js
@@ -2,6 +2,8 @@ import { getMonthlyOverview } from '$lib/monthly-overview.js';
 import { getMontlyPagination } from '$lib/monthly-pagination.js';
 import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
+export { actions } from '$lib/copy-recurring';
+
 export const load = async ({ locals: { supabase } }) => {
 	await gateDynamicPage(supabase);
 	const now = new Date();

--- a/src/routes/overview/[year]/[month]/+page.server.js
+++ b/src/routes/overview/[year]/[month]/+page.server.js
@@ -2,6 +2,8 @@ import { getMonthlyOverview } from '$lib/monthly-overview.js';
 import { getMontlyPagination } from '$lib/monthly-pagination.js';
 import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
 
+export { actions } from '$lib/copy-recurring';
+
 export const load = async ({ params: { year, month }, locals: { supabase } }) => {
 	await gateDynamicPage(supabase);
 


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This adds support for copying recurring expenses to future or current (or I guess past) months when there aren't any expenses for the month, but there are active recurring expenses.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Navigate to a month in the future without any expenses and confirm that the new button shows up
5. Confirm that clicking the button creates the expected expenses and reloads the page with the new data
<!-- Add additional validation steps here -->
