### PR TITLE
feat: support copying the previous month's savings/debt data

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -13,6 +13,8 @@
 		debt,
 		canCopyExpenses,
 		canCopyIncome,
+		canCopySavings,
+		canCopyDebt,
 	} = data;
 </script>
 
@@ -90,6 +92,13 @@
 	</ul>
 {:else}
 	<p>No savings found.</p>
+	{#if canCopySavings}
+		<form method="POST" action="?/copySavings">
+			<input type="hidden" name="year" value={year} />
+			<input type="hidden" name="month" value={month} />
+			<button type="submit">Copy Last Month's Savings</button>
+		</form>
+	{/if}
 {/if}
 <p>
 	<a href="/savings">Add Savings</a>
@@ -106,6 +115,13 @@
 	</ul>
 {:else}
 	<p>No debt found.</p>
+	{#if canCopyDebt}
+		<form method="POST" action="?/copyDebt">
+			<input type="hidden" name="year" value={year} />
+			<input type="hidden" name="month" value={month} />
+			<button type="submit">Copy Last Month's Debt</button>
+		</form>
+	{/if}
 {/if}
 <p>
 	<a href="/debt">Add Debt</a>

--- a/src/lib/monthly-overview.js
+++ b/src/lib/monthly-overview.js
@@ -56,16 +56,48 @@ const hasRecurringIncome = async (supabase) => {
 	return count > 0;
 };
 
+const hasSavingsLastMonth = async (supabase, previousMonth, currentMonth) => {
+	const { count } = await supabase
+		.from('savings')
+		.select('*', { count: 'exact', head: true })
+		.gte('date', previousMonth)
+		.lt('date', currentMonth);
+
+	return count > 0;
+};
+
+const hasDebtLastMonth = async (supabase, previousMonth, currentMonth) => {
+	const { count } = await supabase
+		.from('debt')
+		.select('*', { count: 'exact', head: true })
+		.gte('date', previousMonth)
+		.lt('date', currentMonth);
+
+	return count > 0;
+};
+
 export const getMonthlyOverview = async (supabase, year, month) => {
+	const previousMonth = new Date(year, month - 1, 1).toDateString();
 	const currentMonth = new Date(year, month, 1).toDateString();
 	const nextMonth = new Date(year, month + 1, 1).toDateString();
-	const [expenses, income, savings, debt, canCopyExpenses, canCopyIncome] = await Promise.all([
+	const [
+		expenses,
+		income,
+		savings,
+		debt,
+		canCopyExpenses,
+		canCopyIncome,
+		canCopySavings,
+		canCopyDebt,
+	] = await Promise.all([
 		getExpenses(supabase, currentMonth, nextMonth),
 		getIncome(supabase, currentMonth, nextMonth),
 		getSavings(supabase, currentMonth, nextMonth),
 		getDebt(supabase, currentMonth, nextMonth),
 		hasRecurringExpenses(supabase),
 		hasRecurringIncome(supabase),
+		hasSavingsLastMonth(supabase, previousMonth, currentMonth),
+		hasDebtLastMonth(supabase, previousMonth, currentMonth),
 	]);
 
 	return {
@@ -77,5 +109,7 @@ export const getMonthlyOverview = async (supabase, year, month) => {
 		debt,
 		canCopyExpenses,
 		canCopyIncome,
+		canCopySavings,
+		canCopyDebt,
 	};
 };


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
Unlike expenses or income, this approach simply copies the previous month's savings/debt entries to the new month. The implementation is simpler, but still reuses aspects of the `copyRecurring` strategy.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Attempt to copy savings/debt data, making sure it works as expected
<!-- Add additional validation steps here -->
