### PR TITLE
feat: set up the layout for the overview page

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -28,100 +28,112 @@
 	<a href={next.link} class="cmp-pagination__link" data-sveltekit-reload>{next.text}</a>
 </nav>
 
-<h2>Expenses</h2>
-{#if expenses.length}
-	<ul>
-		{#each expenses as expense}
-			<li>
-				<a href="/expense/{expense.id}">{expense.description}: {expense.amount}</a>
-			</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No expenses found.</p>
-	{#if canCopyExpenses}
-		<form method="POST" action="?/copyExpenses" aria-label="Copy Recurring Expenses">
-			<input type="hidden" name="year" value={year} />
-			<input type="hidden" name="month" value={month} />
-			<button type="submit">Copy Recurring Expenses</button>
-		</form>
-	{/if}
-{/if}
-<p>
-	<a href="/recurring-expenses">Manage Recurring Expenses</a>
-</p>
-<p>
-	<a href="/expense">Add Expense</a>
-</p>
+<div class="obj-overview-grid">
+	<div class="obj-overview-grid__expenses">
+		<h2>Expenses</h2>
+		{#if expenses.length}
+			<ul>
+				{#each expenses as expense}
+					<li>
+						<a href="/expense/{expense.id}">{expense.description}: {expense.amount}</a>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p>No expenses found.</p>
+			{#if canCopyExpenses}
+				<form method="POST" action="?/copyExpenses" aria-label="Copy Recurring Expenses">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit">Copy Recurring Expenses</button>
+				</form>
+			{/if}
+		{/if}
+		<p>
+			<a href="/recurring-expenses">Manage Recurring Expenses</a>
+		</p>
+		<p>
+			<a href="/expense">Add Expense</a>
+		</p>
+	</div>
 
-<h2>Income</h2>
-{#if income.length}
-	<ul>
-		{#each income as incomeEntry}
-			<li>
-				<a href="/income/{incomeEntry.id}">{incomeEntry.description}: {incomeEntry.amount}</a>
-			</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No income found.</p>
-	{#if canCopyIncome}
-		<form method="POST" action="?/copyIncome" aria-label="Copy Recurring Income">
-			<input type="hidden" name="year" value={year} />
-			<input type="hidden" name="month" value={month} />
-			<button type="submit">Copy Recurring Income</button>
-		</form>
-	{/if}
-{/if}
-<p>
-	<a href="/recurring-income">Manage Recurring Income</a>
-</p>
-<p>
-	<a href="/income">Add Income</a>
-</p>
+	<div class="obj-overview-grid__income">
+		<h2>Income</h2>
+		{#if income.length}
+			<ul>
+				{#each income as incomeEntry}
+					<li>
+						<a href="/income/{incomeEntry.id}">{incomeEntry.description}: {incomeEntry.amount}</a>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p>No income found.</p>
+			{#if canCopyIncome}
+				<form method="POST" action="?/copyIncome" aria-label="Copy Recurring Income">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit">Copy Recurring Income</button>
+				</form>
+			{/if}
+		{/if}
+		<p>
+			<a href="/recurring-income">Manage Recurring Income</a>
+		</p>
+		<p>
+			<a href="/income">Add Income</a>
+		</p>
+	</div>
 
-<h2>Savings</h2>
-{#if savings.length}
-	<ul>
-		{#each savings as savingsEntry}
-			<li>
-				<a href="/savings/{savingsEntry.id}">{savingsEntry.description}: {savingsEntry.amount}</a>
-			</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No savings found.</p>
-	{#if canCopySavings}
-		<form method="POST" action="?/copySavings" aria-label="Copy Last Month's Savings">
-			<input type="hidden" name="year" value={year} />
-			<input type="hidden" name="month" value={month} />
-			<button type="submit">Copy Last Month's Savings</button>
-		</form>
-	{/if}
-{/if}
-<p>
-	<a href="/savings">Add Savings</a>
-</p>
+	<div class="obj-overview-grid__savings">
+		<h2>Savings</h2>
+		{#if savings.length}
+			<ul>
+				{#each savings as savingsEntry}
+					<li>
+						<a href="/savings/{savingsEntry.id}"
+							>{savingsEntry.description}: {savingsEntry.amount}</a
+						>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p>No savings found.</p>
+			{#if canCopySavings}
+				<form method="POST" action="?/copySavings" aria-label="Copy Last Month's Savings">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit">Copy Last Month's Savings</button>
+				</form>
+			{/if}
+		{/if}
+		<p>
+			<a href="/savings">Add Savings</a>
+		</p>
+	</div>
 
-<h2>Debt</h2>
-{#if debt.length}
-	<ul>
-		{#each debt as debtEntry}
-			<li>
-				<a href="/debt/{debtEntry.id}">{debtEntry.description}: {debtEntry.amount}</a>
-			</li>
-		{/each}
-	</ul>
-{:else}
-	<p>No debt found.</p>
-	{#if canCopyDebt}
-		<form method="POST" action="?/copyDebt" aria-label="Copy Last Month's Debt">
-			<input type="hidden" name="year" value={year} />
-			<input type="hidden" name="month" value={month} />
-			<button type="submit">Copy Last Month's Debt</button>
-		</form>
-	{/if}
-{/if}
-<p>
-	<a href="/debt">Add Debt</a>
-</p>
+	<div class="obj-overview-grid__debt">
+		<h2>Debt</h2>
+		{#if debt.length}
+			<ul>
+				{#each debt as debtEntry}
+					<li>
+						<a href="/debt/{debtEntry.id}">{debtEntry.description}: {debtEntry.amount}</a>
+					</li>
+				{/each}
+			</ul>
+		{:else}
+			<p>No debt found.</p>
+			{#if canCopyDebt}
+				<form method="POST" action="?/copyDebt" aria-label="Copy Last Month's Debt">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit">Copy Last Month's Debt</button>
+				</form>
+			{/if}
+		{/if}
+		<p>
+			<a href="/debt">Add Debt</a>
+		</p>
+	</div>
+</div>

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -18,16 +18,15 @@
 	} = data;
 </script>
 
-<h1>{formattedDate}</h1>
+<h1 class="util-visually-hidden">{formattedDate}</h1>
 
-<ul>
-	<li>
-		<a href={previous.link} data-sveltekit-reload>{previous.text}</a>
-	</li>
-	<li>
-		<a href={next.link} data-sveltekit-reload>{next.text}</a>
-	</li>
-</ul>
+<nav class="cmp-pagination" aria-label="Monthly overview navigation">
+	<a href={previous.link} class="cmp-pagination__link" data-sveltekit-reload>{previous.text}</a>
+	<a href="/overview/{year}/{month + 1}" class="cmp-pagination__link" aria-current="page"
+		>{formattedDate}</a
+	>
+	<a href={next.link} class="cmp-pagination__link" data-sveltekit-reload>{next.text}</a>
+</nav>
 
 <h2>Expenses</h2>
 {#if expenses.length}

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -29,111 +29,127 @@
 </nav>
 
 <div class="obj-overview-grid">
-	<div class="obj-overview-grid__expenses">
-		<h2>Expenses</h2>
-		{#if expenses.length}
-			<ul>
-				{#each expenses as expense}
-					<li>
-						<a href="/expense/{expense.id}">{expense.description}: {expense.amount}</a>
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p>No expenses found.</p>
-			{#if canCopyExpenses}
-				<form method="POST" action="?/copyExpenses" aria-label="Copy Recurring Expenses">
-					<input type="hidden" name="year" value={year} />
-					<input type="hidden" name="month" value={month} />
-					<button type="submit">Copy Recurring Expenses</button>
-				</form>
+	<div class="obj-overview-grid__section">
+		<div class="obj-overview-grid__section-heading">
+			<h2>Expenses</h2>
+		</div>
+		<div class="obj-overview-grid__section-body">
+			{#if expenses.length}
+				<ul>
+					{#each expenses as expense}
+						<li>
+							<a href="/expense/{expense.id}">{expense.description}: {expense.amount}</a>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p>No expenses found.</p>
+				{#if canCopyExpenses}
+					<form method="POST" action="?/copyExpenses" aria-label="Copy Recurring Expenses">
+						<input type="hidden" name="year" value={year} />
+						<input type="hidden" name="month" value={month} />
+						<button type="submit">Copy Recurring Expenses</button>
+					</form>
+				{/if}
 			{/if}
-		{/if}
-		<p>
-			<a href="/recurring-expenses">Manage Recurring Expenses</a>
-		</p>
-		<p>
-			<a href="/expense">Add Expense</a>
-		</p>
+			<p>
+				<a href="/recurring-expenses">Manage Recurring Expenses</a>
+			</p>
+		</div>
+		<div class="obj-overview-grid__section-footer">
+			<a href="/expense" class="obj-overview-grid__add-link">Add Expense</a>
+		</div>
 	</div>
 
-	<div class="obj-overview-grid__income">
-		<h2>Income</h2>
-		{#if income.length}
-			<ul>
-				{#each income as incomeEntry}
-					<li>
-						<a href="/income/{incomeEntry.id}">{incomeEntry.description}: {incomeEntry.amount}</a>
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p>No income found.</p>
-			{#if canCopyIncome}
-				<form method="POST" action="?/copyIncome" aria-label="Copy Recurring Income">
-					<input type="hidden" name="year" value={year} />
-					<input type="hidden" name="month" value={month} />
-					<button type="submit">Copy Recurring Income</button>
-				</form>
+	<div class="obj-overview-grid__section">
+		<div class="obj-overview-grid__section-heading">
+			<h2>Income</h2>
+		</div>
+		<div class="obj-overview-grid__section-body">
+			{#if income.length}
+				<ul>
+					{#each income as incomeEntry}
+						<li>
+							<a href="/income/{incomeEntry.id}">{incomeEntry.description}: {incomeEntry.amount}</a>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p>No income found.</p>
+				{#if canCopyIncome}
+					<form method="POST" action="?/copyIncome" aria-label="Copy Recurring Income">
+						<input type="hidden" name="year" value={year} />
+						<input type="hidden" name="month" value={month} />
+						<button type="submit">Copy Recurring Income</button>
+					</form>
+				{/if}
 			{/if}
-		{/if}
-		<p>
-			<a href="/recurring-income">Manage Recurring Income</a>
-		</p>
-		<p>
-			<a href="/income">Add Income</a>
-		</p>
+			<p>
+				<a href="/recurring-income">Manage Recurring Income</a>
+			</p>
+		</div>
+		<div class="obj-overview-grid__section-footer">
+			<a href="/income" class="obj-overview-grid__add-link">Add Income</a>
+		</div>
 	</div>
 
-	<div class="obj-overview-grid__savings">
-		<h2>Savings</h2>
-		{#if savings.length}
-			<ul>
-				{#each savings as savingsEntry}
-					<li>
-						<a href="/savings/{savingsEntry.id}"
-							>{savingsEntry.description}: {savingsEntry.amount}</a
-						>
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p>No savings found.</p>
-			{#if canCopySavings}
-				<form method="POST" action="?/copySavings" aria-label="Copy Last Month's Savings">
-					<input type="hidden" name="year" value={year} />
-					<input type="hidden" name="month" value={month} />
-					<button type="submit">Copy Last Month's Savings</button>
-				</form>
+	<div class="obj-overview-grid__section">
+		<div class="obj-overview-grid__section-heading">
+			<h2>Savings</h2>
+		</div>
+		<div class="obj-overview-grid__section-body">
+			{#if savings.length}
+				<ul>
+					{#each savings as savingsEntry}
+						<li>
+							<a href="/savings/{savingsEntry.id}"
+								>{savingsEntry.description}: {savingsEntry.amount}</a
+							>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p>No savings found.</p>
+				{#if canCopySavings}
+					<form method="POST" action="?/copySavings" aria-label="Copy Last Month's Savings">
+						<input type="hidden" name="year" value={year} />
+						<input type="hidden" name="month" value={month} />
+						<button type="submit">Copy Last Month's Savings</button>
+					</form>
+				{/if}
 			{/if}
-		{/if}
-		<p>
-			<a href="/savings">Add Savings</a>
-		</p>
+		</div>
+		<div class="obj-overview-grid__section-footer">
+			<a href="/savings" class="obj-overview-grid__add-link">Add Savings</a>
+		</div>
 	</div>
 
-	<div class="obj-overview-grid__debt">
-		<h2>Debt</h2>
-		{#if debt.length}
-			<ul>
-				{#each debt as debtEntry}
-					<li>
-						<a href="/debt/{debtEntry.id}">{debtEntry.description}: {debtEntry.amount}</a>
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p>No debt found.</p>
-			{#if canCopyDebt}
-				<form method="POST" action="?/copyDebt" aria-label="Copy Last Month's Debt">
-					<input type="hidden" name="year" value={year} />
-					<input type="hidden" name="month" value={month} />
-					<button type="submit">Copy Last Month's Debt</button>
-				</form>
+	<div class="obj-overview-grid__section">
+		<div class="obj-overview-grid__section-heading">
+			<h2>Debt</h2>
+		</div>
+		<div class="obj-overview-grid__section-body">
+			{#if debt.length}
+				<ul>
+					{#each debt as debtEntry}
+						<li>
+							<a href="/debt/{debtEntry.id}">{debtEntry.description}: {debtEntry.amount}</a>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p>No debt found.</p>
+				{#if canCopyDebt}
+					<form method="POST" action="?/copyDebt" aria-label="Copy Last Month's Debt">
+						<input type="hidden" name="year" value={year} />
+						<input type="hidden" name="month" value={month} />
+						<button type="submit">Copy Last Month's Debt</button>
+					</form>
+				{/if}
 			{/if}
-		{/if}
-		<p>
-			<a href="/debt">Add Debt</a>
-		</p>
+		</div>
+		<div class="obj-overview-grid__section-footer">
+			<a href="/debt" class="obj-overview-grid__add-link">Add Debt</a>
+		</div>
 	</div>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,13 +25,13 @@
 	<title>{$page.data.title ?? 'bvdget'} | bvdget</title>
 </svelte:head>
 <header>
-	<nav>
+	<nav class="cmp-navigation" aria-label="Primary navigation">
 		{#if session != null}
-			<a href="/overview">Overview</a>
-			<a href="/auth/sign-out">Sign out</a>
+			<a href="/overview" class="cmp-navigation__link">Overview</a>
+			<a href="/auth/sign-out" class="cmp-navigation__link">Sign out</a>
 		{:else}
-			<a href="/">Home</a>
-			<a href="/auth/login">Log in/sign up</a>
+			<a href="/" class="cmp-navigation__link">Home</a>
+			<a href="/auth/login" class="cmp-navigation__link">Log in/sign up</a>
 		{/if}
 	</nav>
 </header>

--- a/src/routes/auth/confirm/+page.svelte
+++ b/src/routes/auth/confirm/+page.svelte
@@ -4,21 +4,23 @@
 	let { session } = data;
 </script>
 
-<h1>Confirm Login</h1>
+<div class="obj-content-container">
+	<h1>Confirm Login</h1>
 
-{#if session?.user?.email != null}
-	<p>
-		You are already logged in as <em>{session.user.email}</em>.
-		<a href="/auth/sign-out">Sign out</a>
-		to change accounts, or go back to your <a href="/overview">overview page</a>.
-	</p>
-{:else}
-	<p>Check your email for a one-time code that you can use to confirm your login.</p>
+	{#if session?.user?.email != null}
+		<p>
+			You are already logged in as <em>{session.user.email}</em>.
+			<a href="/auth/sign-out">Sign out</a>
+			to change accounts, or go back to your <a href="/overview">overview page</a>.
+		</p>
+	{:else}
+		<p>Check your email for a one-time code that you can use to confirm your login.</p>
 
-	<form method="POST" aria-label="Finish logging in">
-		<input type="hidden" name="email" value={data.email} />
-		<label for="token">One-time code</label>
-		<input id="token" type="text" name="token" inputmode="numeric" autocomplete="one-time-code" />
-		<button type="submit">Finish logging in</button>
-	</form>
-{/if}
+		<form method="POST" aria-label="Finish logging in">
+			<input type="hidden" name="email" value={data.email} />
+			<label for="token">One-time code</label>
+			<input id="token" type="text" name="token" inputmode="numeric" autocomplete="one-time-code" />
+			<button type="submit">Finish logging in</button>
+		</form>
+	{/if}
+</div>

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -4,23 +4,25 @@
 	let { session } = data;
 </script>
 
-<h1>Log in or sign up</h1>
+<div class="obj-content-container">
+	<h1>Log in or sign up</h1>
 
-{#if session?.user?.email != null}
-	<p>
-		You are already logged in as <em>{session.user.email}</em>.
-		<a href="/auth/sign-out">Sign out</a>
-		to change accounts, or go back to your <a href="/overview">overview page</a>.
-	</p>
-{:else}
-	<p>
-		We will send you an email with a one-time code that you can use to finish logging in. If you
-		don't have an account already, one will be created automatically.
-	</p>
+	{#if session?.user?.email != null}
+		<p>
+			You are already logged in as <em>{session.user.email}</em>.
+			<a href="/auth/sign-out">Sign out</a>
+			to change accounts, or go back to your <a href="/overview">overview page</a>.
+		</p>
+	{:else}
+		<p>
+			We will send you an email with a one-time code that you can use to finish logging in. If you
+			don't have an account already, one will be created automatically.
+		</p>
 
-	<form method="POST" aria-label="Request one-time code">
-		<label for="email">Email</label>
-		<input id="email" type="email" name="email" autocomplete="email" />
-		<button type="submit">Request one-time code</button>
-	</form>
-{/if}
+		<form method="POST" aria-label="Request one-time code">
+			<label for="email">Email</label>
+			<input id="email" type="email" name="email" autocomplete="email" />
+			<button type="submit">Request one-time code</button>
+		</form>
+	{/if}
+</div>

--- a/src/scss/components/_navigation.scss
+++ b/src/scss/components/_navigation.scss
@@ -1,0 +1,15 @@
+.cmp-navigation {
+	display: flex;
+	flex-flow: row wrap;
+	gap: 1rem;
+	justify-content: space-between;
+
+	&__link {
+		font-size: 1.25rem;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+}

--- a/src/scss/components/_pagination.scss
+++ b/src/scss/components/_pagination.scss
@@ -1,16 +1,15 @@
-.cmp-navigation {
+.cmp-pagination {
 	display: flex;
 	flex-flow: row wrap;
 	gap: 1rem;
 	justify-content: space-between;
-	margin-block-end: 2rem;
 
 	&__link {
 		font-size: 1.25rem;
-		text-decoration: none;
 
-		&:hover {
-			text-decoration: underline;
+		&[aria-current='page'] {
+			text-decoration: none;
+			color: var(--brand-foreground);
 		}
 	}
 }

--- a/src/scss/objects/_container.scss
+++ b/src/scss/objects/_container.scss
@@ -1,5 +1,5 @@
 .obj-container {
 	width: min(75rem, 100vw - 2rem);
 	margin-inline: auto;
-	padding-block: 1rem;
+	padding-block-start: 1rem;
 }

--- a/src/scss/objects/_content-container.scss
+++ b/src/scss/objects/_content-container.scss
@@ -1,0 +1,3 @@
+.obj-content-container {
+	width: min(75ch, 100%);
+}

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -1,0 +1,23 @@
+.obj-overview-grid {
+	display: grid;
+	grid-template-columns: repeat(4, minmax(18rem, 1fr));
+	gap: 1rem;
+	overflow-x: auto;
+	scroll-snap-type: x mandatory;
+
+	&__expenses {
+		scroll-snap-align: start;
+	}
+
+	&__income {
+		scroll-snap-align: start;
+	}
+
+	&__savings {
+		scroll-snap-align: start;
+	}
+
+	&__debt {
+		scroll-snap-align: start;
+	}
+}

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -1,23 +1,30 @@
 .obj-overview-grid {
 	display: grid;
 	grid-template-columns: repeat(4, minmax(18rem, 1fr));
-	gap: 1rem;
+	grid-template-rows: auto calc(100dvh - 14rem) auto;
+	column-gap: 1rem;
 	overflow-x: auto;
+	overflow-y: hidden;
 	scroll-snap-type: x mandatory;
 
-	&__expenses {
+	&__section {
 		scroll-snap-align: start;
+		display: grid;
+		grid-template-columns: 1fr;
+		grid-template-rows: subgrid;
+		grid-row: 1 / -1;
 	}
 
-	&__income {
-		scroll-snap-align: start;
+	&__section-heading {
+		grid-row: 1 / 2;
 	}
 
-	&__savings {
-		scroll-snap-align: start;
+	&__section-body {
+		grid-row: 2 / 3;
+		overflow-y: auto;
 	}
 
-	&__debt {
-		scroll-snap-align: start;
+	&__section-footer {
+		grid-row: 3 / 4;
 	}
 }

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -1,30 +1,32 @@
-.obj-overview-grid {
-	display: grid;
-	grid-template-columns: repeat(4, minmax(18rem, 1fr));
-	grid-template-rows: auto calc(100dvh - 14rem) auto;
-	column-gap: 1rem;
-	overflow-x: auto;
-	overflow-y: hidden;
-	scroll-snap-type: x mandatory;
-
-	&__section {
-		scroll-snap-align: start;
+@media (min-height: 20rem) {
+	.obj-overview-grid {
 		display: grid;
-		grid-template-columns: 1fr;
-		grid-template-rows: subgrid;
-		grid-row: 1 / -1;
-	}
+		grid-template-columns: repeat(4, minmax(18rem, 1fr));
+		grid-template-rows: auto calc(100dvh - 14rem) auto;
+		column-gap: 1rem;
+		overflow-x: auto;
+		overflow-y: hidden;
+		scroll-snap-type: x mandatory;
 
-	&__section-heading {
-		grid-row: 1 / 2;
-	}
+		&__section {
+			scroll-snap-align: start;
+			display: grid;
+			grid-template-columns: 1fr;
+			grid-template-rows: subgrid;
+			grid-row: 1 / -1;
+		}
 
-	&__section-body {
-		grid-row: 2 / 3;
-		overflow-y: auto;
-	}
+		&__section-heading {
+			grid-row: 1 / 2;
+		}
 
-	&__section-footer {
-		grid-row: 3 / 4;
+		&__section-body {
+			grid-row: 2 / 3;
+			overflow-y: auto;
+		}
+
+		&__section-footer {
+			grid-row: 3 / 4;
+		}
 	}
 }

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -2,7 +2,7 @@
 	.obj-overview-grid {
 		display: grid;
 		grid-template-columns: repeat(4, minmax(18rem, 1fr));
-		grid-template-rows: auto calc(100dvh - 14rem) auto;
+		grid-template-rows: auto calc(100dvh - 15rem) auto;
 		column-gap: 1rem;
 		overflow-x: auto;
 		overflow-y: hidden;
@@ -27,6 +27,16 @@
 
 		&__section-footer {
 			grid-row: 3 / 4;
+		}
+
+		&__add-link {
+			box-sizing: border-box;
+			display: block;
+			border: 2px solid currentColor;
+			font-size: 1.25rem;
+			text-align: center;
+			text-decoration: none;
+			padding-block: 0.5rem;
 		}
 	}
 }

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -4,8 +4,7 @@
 		grid-template-columns: repeat(4, minmax(18rem, 1fr));
 		grid-template-rows: auto calc(100dvh - 15rem) auto;
 		column-gap: 1rem;
-		overflow-x: auto;
-		overflow-y: hidden;
+		overflow: auto hidden;
 		scroll-snap-type: x mandatory;
 
 		&__section {
@@ -32,7 +31,7 @@
 		&__add-link {
 			box-sizing: border-box;
 			display: block;
-			border: 2px solid currentColor;
+			border: 2px solid currentcolor;
 			font-size: 1.25rem;
 			text-align: center;
 			text-decoration: none;

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -3,6 +3,7 @@
 @forward './elements/a';
 @forward './objects/container';
 @forward './objects/content-container';
+@forward './objects/overview-grid';
 @forward './components/navigation';
 @forward './components/pagination';
 @forward './utilities/visually-hidden';

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -2,3 +2,4 @@
 @forward './elements/root';
 @forward './elements/a';
 @forward './objects/container';
+@forward './components/navigation';

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -2,4 +2,5 @@
 @forward './elements/root';
 @forward './elements/a';
 @forward './objects/container';
+@forward './objects/content-container';
 @forward './components/navigation';

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -4,3 +4,5 @@
 @forward './objects/container';
 @forward './objects/content-container';
 @forward './components/navigation';
+@forward './components/pagination';
+@forward './utilities/visually-hidden';

--- a/src/scss/utilities/_visually-hidden.scss
+++ b/src/scss/utilities/_visually-hidden.scss
@@ -1,0 +1,8 @@
+.util-visually-hidden:not(:focus) {
+	position: absolute;
+	height: 1px;
+	width: 1px;
+	clip-path: inset(50%);
+	overflow: hidden;
+	white-space: nowrap;
+}


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This work styles the overview page to mostly match cashcache.io, but I may revisit it later. Subgrid helps, but it's still a little too reliant on magic numbers, and I don't know how it'll work with mobile browsers and their address bars. Either way, this will get the job done for now.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Zoom in to 200%, then 400%, confirming that all links on the overview page are accessible
5. Check the deploy preview on your phone with different browsers, ensuring that there's minimal jankiness
<!-- Add additional validation steps here -->
