### PR TITLE
feat: redesign overview page

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -38,8 +38,8 @@
 </nav>
 
 <div class="obj-overview-grid">
-	<div class="obj-overview-grid__section">
-		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+	<section class="obj-overview-grid__section" aria-labelledby="expenses">
+		<h2 id="expenses" class="obj-overview-grid__section-heading cmp-split-heading">
 			<span>Expenses</span>
 			<span>{formatCurrency(expensesTotal)}</span>
 		</h2>
@@ -77,10 +77,10 @@
 				</form>
 			{/if}
 		{/if}
-	</div>
+	</section>
 
-	<div class="obj-overview-grid__section">
-		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+	<section class="obj-overview-grid__section" aria-labelledby="income">
+		<h2 id="income" class="obj-overview-grid__section-heading cmp-split-heading">
 			<span>Income</span>
 			<span>{formatCurrency(incomeTotal)}</span>
 		</h2>
@@ -118,10 +118,10 @@
 				</form>
 			{/if}
 		{/if}
-	</div>
+	</section>
 
-	<div class="obj-overview-grid__section">
-		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+	<section class="obj-overview-grid__section" aria-labelledby="savings">
+		<h2 id="savings" class="obj-overview-grid__section-heading cmp-split-heading">
 			<span>Savings</span>
 			<span>{formatCurrency(savingsTotal)}</span>
 		</h2>
@@ -155,10 +155,10 @@
 				</form>
 			{/if}
 		{/if}
-	</div>
+	</section>
 
-	<div class="obj-overview-grid__section">
-		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+	<section class="obj-overview-grid__section" aria-labelledby="debt">
+		<h2 id="debt" class="obj-overview-grid__section-heading cmp-split-heading">
 			<span>Debt</span>
 			<span>{formatCurrency(debtTotal)}</span>
 		</h2>
@@ -192,5 +192,5 @@
 				</form>
 			{/if}
 		{/if}
-	</div>
+	</section>
 </div>

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -39,174 +39,158 @@
 
 <div class="obj-overview-grid">
 	<div class="obj-overview-grid__section">
-		<div class="obj-overview-grid__section-heading">
-			<h2 class="cmp-split-heading">
-				<span>Expenses</span>
-				<span>{formatCurrency(expensesTotal)}</span>
-			</h2>
-		</div>
-		<div class="obj-overview-grid__section-body">
-			{#if expenses.length}
-				{#each expenses as category}
-					<h3 class="cmp-split-heading">
-						<span>{category.name}</span>
-						<span>{formatCurrency(category.amount)}</span>
-					</h3>
-					<dl>
-						{#each category.entries as expense}
-							<div class="cmp-entry-summary">
-								<dt class="cmp-entry-summary__description">
-									<a href="/expense/{expense.id}">{expense.description}</a>
-								</dt>
-								<dd class="cmp-entry-summary__date">{formatDate(expense.date)}</dd>
-								<dd class="cmp-entry-summary__amount">{formatCurrency(expense.amount)}</dd>
-							</div>
-						{/each}
-					</dl>
-				{/each}
-			{:else}
-				<p>No expenses found.</p>
-				{#if canCopyExpenses}
-					<form method="POST" action="?/copyExpenses" aria-label="Copy Recurring Expenses">
-						<input type="hidden" name="year" value={year} />
-						<input type="hidden" name="month" value={month} />
-						<button type="submit">Copy Recurring Expenses</button>
-					</form>
-				{/if}
-			{/if}
-			<p>
-				<a href="/recurring-expenses">Manage Recurring Expenses</a>
-			</p>
-		</div>
-		<div class="obj-overview-grid__section-footer">
+		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+			<span>Expenses</span>
+			<span>{formatCurrency(expensesTotal)}</span>
+		</h2>
+		<div>
 			<a href="/expense" class="obj-overview-grid__add-link">Add Expense</a>
 		</div>
+		<p>
+			<a href="/recurring-expenses">Manage Recurring Expenses</a>
+		</p>
+		{#if expenses.length}
+			{#each expenses as category}
+				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
+					<span>{category.name}</span>
+					<span>{formatCurrency(category.amount)}</span>
+				</h3>
+				<dl>
+					{#each category.entries as expense}
+						<div class="cmp-entry-summary">
+							<dt class="cmp-entry-summary__description">
+								<a href="/expense/{expense.id}">{expense.description}</a>
+							</dt>
+							<dd class="cmp-entry-summary__date">{formatDate(expense.date)}</dd>
+							<dd class="cmp-entry-summary__amount">{formatCurrency(expense.amount)}</dd>
+						</div>
+					{/each}
+				</dl>
+			{/each}
+		{:else}
+			<p>No expenses found.</p>
+			{#if canCopyExpenses}
+				<form method="POST" action="?/copyExpenses" aria-label="Copy Recurring Expenses">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit" class="cmp-form__button">Copy Recurring Expenses</button>
+				</form>
+			{/if}
+		{/if}
 	</div>
 
 	<div class="obj-overview-grid__section">
-		<div class="obj-overview-grid__section-heading">
-			<h2 class="cmp-split-heading">
-				<span>Income</span>
-				<span>{formatCurrency(incomeTotal)}</span>
-			</h2>
-		</div>
-		<div class="obj-overview-grid__section-body">
-			{#if income.length}
-				{#each income as category}
-					<h3 class="cmp-split-heading">
-						<span>{category.name}</span>
-						<span>{formatCurrency(category.amount)}</span>
-					</h3>
-					<dl>
-						{#each category.entries as incomeEntry}
-							<div class="cmp-entry-summary">
-								<dt class="cmp-entry-summary__description">
-									<a href="/income/{incomeEntry.id}">{incomeEntry.description}</a>
-								</dt>
-								<dd class="cmp-entry-summary__date">{formatDate(incomeEntry.date)}</dd>
-								<dd class="cmp-entry-summary__amount">{formatCurrency(incomeEntry.amount)}</dd>
-							</div>
-						{/each}
-					</dl>
-				{/each}
-			{:else}
-				<p>No income found.</p>
-				{#if canCopyIncome}
-					<form method="POST" action="?/copyIncome" aria-label="Copy Recurring Income">
-						<input type="hidden" name="year" value={year} />
-						<input type="hidden" name="month" value={month} />
-						<button type="submit">Copy Recurring Income</button>
-					</form>
-				{/if}
-			{/if}
-			<p>
-				<a href="/recurring-income">Manage Recurring Income</a>
-			</p>
-		</div>
-		<div class="obj-overview-grid__section-footer">
+		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+			<span>Income</span>
+			<span>{formatCurrency(incomeTotal)}</span>
+		</h2>
+		<div>
 			<a href="/income" class="obj-overview-grid__add-link">Add Income</a>
 		</div>
+		<p>
+			<a href="/recurring-income">Manage Recurring Income</a>
+		</p>
+		{#if income.length}
+			{#each income as category}
+				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
+					<span>{category.name}</span>
+					<span>{formatCurrency(category.amount)}</span>
+				</h3>
+				<dl>
+					{#each category.entries as incomeEntry}
+						<div class="cmp-entry-summary">
+							<dt class="cmp-entry-summary__description">
+								<a href="/income/{incomeEntry.id}">{incomeEntry.description}</a>
+							</dt>
+							<dd class="cmp-entry-summary__date">{formatDate(incomeEntry.date)}</dd>
+							<dd class="cmp-entry-summary__amount">{formatCurrency(incomeEntry.amount)}</dd>
+						</div>
+					{/each}
+				</dl>
+			{/each}
+		{:else}
+			<p>No income found.</p>
+			{#if canCopyIncome}
+				<form method="POST" action="?/copyIncome" aria-label="Copy Recurring Income">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit" class="cmp-form__button">Copy Recurring Income</button>
+				</form>
+			{/if}
+		{/if}
 	</div>
 
 	<div class="obj-overview-grid__section">
-		<div class="obj-overview-grid__section-heading">
-			<h2 class="cmp-split-heading">
-				<span>Savings</span>
-				<span>{formatCurrency(savingsTotal)}</span>
-			</h2>
-		</div>
-		<div class="obj-overview-grid__section-body">
-			{#if savings.length}
-				{#each savings as category}
-					<h3 class="cmp-split-heading">
-						<span>{category.name}</span>
-						<span>{formatCurrency(category.amount)}</span>
-					</h3>
-					<dl>
-						{#each category.entries as savingsEntry}
-							<div class="cmp-entry-summary">
-								<dt class="cmp-entry-summary__description">
-									<a href="/savings/{savingsEntry.id}">{savingsEntry.description}</a>
-								</dt>
-								<dd class="cmp-entry-summary__amount">{formatCurrency(savingsEntry.amount)}</dd>
-							</div>
-						{/each}
-					</dl>
-				{/each}
-			{:else}
-				<p>No savings found.</p>
-				{#if canCopySavings}
-					<form method="POST" action="?/copySavings" aria-label="Copy Last Month's Savings">
-						<input type="hidden" name="year" value={year} />
-						<input type="hidden" name="month" value={month} />
-						<button type="submit">Copy Last Month's Savings</button>
-					</form>
-				{/if}
-			{/if}
-		</div>
-		<div class="obj-overview-grid__section-footer">
+		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+			<span>Savings</span>
+			<span>{formatCurrency(savingsTotal)}</span>
+		</h2>
+		<div>
 			<a href="/savings" class="obj-overview-grid__add-link">Add Savings</a>
 		</div>
+		{#if savings.length}
+			{#each savings as category}
+				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
+					<span>{category.name}</span>
+					<span>{formatCurrency(category.amount)}</span>
+				</h3>
+				<dl>
+					{#each category.entries as savingsEntry}
+						<div class="cmp-entry-summary">
+							<dt class="cmp-entry-summary__description">
+								<a href="/savings/{savingsEntry.id}">{savingsEntry.description}</a>
+							</dt>
+							<dd class="cmp-entry-summary__amount">{formatCurrency(savingsEntry.amount)}</dd>
+						</div>
+					{/each}
+				</dl>
+			{/each}
+		{:else}
+			<p>No savings found.</p>
+			{#if canCopySavings}
+				<form method="POST" action="?/copySavings" aria-label="Copy Last Month's Savings">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit" class="cmp-form__button">Copy Last Month's Savings</button>
+				</form>
+			{/if}
+		{/if}
 	</div>
 
 	<div class="obj-overview-grid__section">
-		<div class="obj-overview-grid__section-heading">
-			<h2 class="cmp-split-heading">
-				<span>Debt</span>
-				<span>{formatCurrency(debtTotal)}</span>
-			</h2>
-		</div>
-		<div class="obj-overview-grid__section-body">
-			{#if debt.length}
-				{#each debt as category}
-					<h3 class="cmp-split-heading">
-						<span>{category.name}</span>
-						<span>{formatCurrency(category.amount)}</span>
-					</h3>
-					<dl>
-						{#each category.entries as debtEntry}
-							<div class="cmp-entry-summary">
-								<dt class="cmp-entry-summary__description">
-									<a href="/debt/{debtEntry.id}">{debtEntry.description}</a>
-								</dt>
-								<dd class="cmp-entry-summary__amount">{formatCurrency(debtEntry.amount)}</dd>
-							</div>
-						{/each}
-					</dl>
-				{/each}
-			{:else}
-				<p>No debt found.</p>
-				{#if canCopyDebt}
-					<form method="POST" action="?/copyDebt" aria-label="Copy Last Month's Debt">
-						<input type="hidden" name="year" value={year} />
-						<input type="hidden" name="month" value={month} />
-						<button type="submit">Copy Last Month's Debt</button>
-					</form>
-				{/if}
-			{/if}
-		</div>
-		<div class="obj-overview-grid__section-footer">
+		<h2 class="obj-overview-grid__section-heading cmp-split-heading">
+			<span>Debt</span>
+			<span>{formatCurrency(debtTotal)}</span>
+		</h2>
+		<div>
 			<a href="/debt" class="obj-overview-grid__add-link">Add Debt</a>
 		</div>
+		{#if debt.length}
+			{#each debt as category}
+				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
+					<span>{category.name}</span>
+					<span>{formatCurrency(category.amount)}</span>
+				</h3>
+				<dl>
+					{#each category.entries as debtEntry}
+						<div class="cmp-entry-summary">
+							<dt class="cmp-entry-summary__description">
+								<a href="/debt/{debtEntry.id}">{debtEntry.description}</a>
+							</dt>
+							<dd class="cmp-entry-summary__amount">{formatCurrency(debtEntry.amount)}</dd>
+						</div>
+					{/each}
+				</dl>
+			{/each}
+		{:else}
+			<p>No debt found.</p>
+			{#if canCopyDebt}
+				<form method="POST" action="?/copyDebt" aria-label="Copy Last Month's Debt">
+					<input type="hidden" name="year" value={year} />
+					<input type="hidden" name="month" value={month} />
+					<button type="submit" class="cmp-form__button">Copy Last Month's Debt</button>
+				</form>
+			{/if}
+		{/if}
 	</div>
 </div>

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -29,6 +29,13 @@
 
 <h1 class="util-visually-hidden">{formattedDate}</h1>
 
+<nav aria-label="Skip links">
+	<a href="#expenses" class="util-visually-hidden">Skip to expenses</a>
+	<a href="#income" class="util-visually-hidden">Skip to income</a>
+	<a href="#savings" class="util-visually-hidden">Skip to savings</a>
+	<a href="#debt" class="util-visually-hidden">Skip to debt</a>
+</nav>
+
 <nav class="cmp-pagination" aria-label="Monthly overview navigation">
 	<a href={previous.link} class="cmp-pagination__link" data-sveltekit-reload>{previous.text}</a>
 	<a href="/overview/{year}/{month + 1}" class="cmp-pagination__link" aria-current="page"
@@ -49,6 +56,7 @@
 		<p>
 			<a href="/recurring-expenses">Manage Recurring Expenses</a>
 		</p>
+		<a href="#income" class="util-visually-hidden">Skip to income</a>
 		{#if expenses.length}
 			{#each expenses as category}
 				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
@@ -90,6 +98,7 @@
 		<p>
 			<a href="/recurring-income">Manage Recurring Income</a>
 		</p>
+		<a href="#savings" class="util-visually-hidden">Skip to savings</a>
 		{#if income.length}
 			{#each income as category}
 				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
@@ -128,6 +137,7 @@
 		<div>
 			<a href="/savings" class="obj-overview-grid__add-link">Add Savings</a>
 		</div>
+		<a href="#debt" class="util-visually-hidden">Skip to debt</a>
 		{#if savings.length}
 			{#each savings as category}
 				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">
@@ -165,6 +175,7 @@
 		<div>
 			<a href="/debt" class="obj-overview-grid__add-link">Add Debt</a>
 		</div>
+		<a href="#expenses" class="util-visually-hidden">Go to expenses</a>
 		{#if debt.length}
 			{#each debt as category}
 				<h3 class="obj-overview-grid__section-subheading cmp-split-heading">

--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -51,7 +51,7 @@
 			<span>{formatCurrency(expensesTotal)}</span>
 		</h2>
 		<div>
-			<a href="/expense" class="obj-overview-grid__add-link">Add Expense</a>
+			<a href="/expense" class="cmp-form__button">Add Expense</a>
 		</div>
 		<p>
 			<a href="/recurring-expenses">Manage Recurring Expenses</a>
@@ -93,7 +93,7 @@
 			<span>{formatCurrency(incomeTotal)}</span>
 		</h2>
 		<div>
-			<a href="/income" class="obj-overview-grid__add-link">Add Income</a>
+			<a href="/income" class="cmp-form__button">Add Income</a>
 		</div>
 		<p>
 			<a href="/recurring-income">Manage Recurring Income</a>
@@ -135,7 +135,7 @@
 			<span>{formatCurrency(savingsTotal)}</span>
 		</h2>
 		<div>
-			<a href="/savings" class="obj-overview-grid__add-link">Add Savings</a>
+			<a href="/savings" class="cmp-form__button">Add Savings</a>
 		</div>
 		<a href="#debt" class="util-visually-hidden">Skip to debt</a>
 		{#if savings.length}
@@ -173,7 +173,7 @@
 			<span>{formatCurrency(debtTotal)}</span>
 		</h2>
 		<div>
-			<a href="/debt" class="obj-overview-grid__add-link">Add Debt</a>
+			<a href="/debt" class="cmp-form__button">Add Debt</a>
 		</div>
 		<a href="#expenses" class="util-visually-hidden">Go to expenses</a>
 		{#if debt.length}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,6 +30,7 @@
 	/>
 </svelte:head>
 <header>
+	<a href="#main" class="util-visually-hidden">Skip to main content</a>
 	<nav class="cmp-navigation" aria-label="Primary navigation">
 		{#if session != null}
 			<a href="/overview" class="cmp-navigation__link">Overview</a>
@@ -40,6 +41,6 @@
 		{/if}
 	</nav>
 </header>
-<main>
+<main id="main">
 	<slot />
 </main>

--- a/src/routes/recurring-expenses/+page.svelte
+++ b/src/routes/recurring-expenses/+page.svelte
@@ -8,6 +8,9 @@
 
 <h1>Recurring Expenses</h1>
 
+<p>
+	<a href="/recurring-expenses/expense" class="cmp-form__button">Add Recurring Expense</a>
+</p>
 {#if data.recurringExpenses.length}
 	<dl class="cmp-entry-summary__wrapper">
 		{#each data.recurringExpenses as expense}
@@ -34,6 +37,3 @@
 {:else}
 	<p>No recurring expenses found.</p>
 {/if}
-<p>
-	<a href="/recurring-expenses/expense">Add Recurring Expense</a>
-</p>

--- a/src/routes/recurring-income/+page.svelte
+++ b/src/routes/recurring-income/+page.svelte
@@ -8,6 +8,9 @@
 
 <h1>Recurring Income</h1>
 
+<p>
+	<a href="/recurring-income/income" class="cmp-form__button">Add Recurring Income</a>
+</p>
 {#if data.recurringIncome.length}
 	<dl class="cmp-entry-summary__wrapper">
 		{#each data.recurringIncome as income}
@@ -34,6 +37,3 @@
 {:else}
 	<p>No recurring income found.</p>
 {/if}
-<p>
-	<a href="/recurring-income/income">Add Recurring Income</a>
-</p>

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -39,15 +39,18 @@
 		border: 2px solid var(--brand-primary);
 		padding: 0.5rem;
 		font-weight: 700;
+		text-decoration: none;
 
 		&:hover {
 			background-color: var(--brand-secondary);
 			border-color: var(--brand-secondary);
+			color: var(--brand-background);
 		}
 
 		&:focus {
 			background-color: var(--brand-secondary);
 			border-color: var(--brand-secondary);
+			color: var(--brand-background);
 			outline-color: var(--brand-secondary);
 			outline-offset: 3px;
 			outline-width: 3px;

--- a/src/scss/components/_split-heading.scss
+++ b/src/scss/components/_split-heading.scss
@@ -4,6 +4,6 @@
 	gap: 1rem;
 	justify-content: space-between;
 	align-items: end;
-	padding: 0 0.5rem 0.5rem;
+	padding: 0.5rem;
 	border-bottom: 2px solid currentcolor;
 }

--- a/src/scss/elements/_a.scss
+++ b/src/scss/elements/_a.scss
@@ -5,13 +5,4 @@ a {
 	&:hover {
 		color: var(--brand-secondary);
 	}
-
-	&:visited {
-		color: var(--brand-primary);
-
-		&:focus,
-		&:hover {
-			color: var(--brand-secondary);
-		}
-	}
 }

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -4,30 +4,6 @@
 	gap: 2rem 1rem;
 	margin-block-start: 1rem;
 
-	&__add-link {
-		background-color: var(--brand-primary);
-		color: var(--brand-background);
-		border: 2px solid var(--brand-primary);
-		padding: 0.5rem;
-		font-weight: 700;
-		text-decoration: none;
-
-		&:hover {
-			background-color: var(--brand-secondary);
-			border-color: var(--brand-secondary);
-			color: var(--brand-background);
-		}
-
-		&:focus {
-			background-color: var(--brand-secondary);
-			border-color: var(--brand-secondary);
-			color: var(--brand-background);
-			outline-color: var(--brand-secondary);
-			outline-offset: 3px;
-			outline-width: 3px;
-		}
-	}
-
 	&__section {
 		position: relative;
 		padding: 0 0.5rem 0.5rem;

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -1,42 +1,53 @@
-@media (min-height: 20rem) {
-	.obj-overview-grid {
-		display: grid;
-		grid-template-columns: repeat(4, minmax(18rem, 1fr));
-		grid-template-rows: auto calc(100dvh - 15.5rem) auto;
-		column-gap: 1rem;
-		overflow: auto hidden;
-		scroll-snap-type: x mandatory;
+.obj-overview-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+	gap: 2rem 1rem;
+	margin-block-start: 1rem;
 
-		&__section {
-			scroll-snap-align: start;
-			display: grid;
-			grid-template-columns: 1fr;
-			grid-template-rows: subgrid;
-			grid-row: 1 / -1;
+	&__add-link {
+		background-color: var(--brand-primary);
+		color: var(--brand-background);
+		border: 2px solid var(--brand-primary);
+		padding: 0.5rem;
+		font-weight: 700;
+		text-decoration: none;
+
+		&:hover {
+			background-color: var(--brand-secondary);
+			border-color: var(--brand-secondary);
+			color: var(--brand-background);
 		}
 
-		&__section-heading {
-			grid-row: 1 / 2;
+		&:focus {
+			background-color: var(--brand-secondary);
+			border-color: var(--brand-secondary);
+			color: var(--brand-background);
+			outline-color: var(--brand-secondary);
+			outline-offset: 3px;
+			outline-width: 3px;
 		}
+	}
 
-		&__section-body {
-			grid-row: 2 / 3;
-			overflow-y: auto;
-			padding-inline: 0.5rem;
-		}
+	&__section {
+		padding: 0 0.5rem 0.5rem;
 
-		&__section-footer {
-			grid-row: 3 / 4;
+		@media (min-width: 39rem) {
+			max-height: calc(100dvh - 9rem);
+			overflow: auto;
 		}
+	}
 
-		&__add-link {
-			box-sizing: border-box;
-			display: block;
-			border: 2px solid currentcolor;
-			font-size: 1.25rem;
-			text-align: center;
-			text-decoration: none;
-			padding-block: 0.5rem;
-		}
+	&__section-heading {
+		position: sticky;
+		top: 0;
+		background-color: var(--brand-background);
+		margin-block: 0 1.5rem;
+		padding-block-start: 0.25rem;
+	}
+
+	&__section-subheading {
+		position: sticky;
+		top: 3.125rem;
+		background-color: var(--brand-background);
 	}
 }

--- a/src/scss/objects/_overview-grid.scss
+++ b/src/scss/objects/_overview-grid.scss
@@ -29,6 +29,7 @@
 	}
 
 	&__section {
+		position: relative;
 		padding: 0 0.5rem 0.5rem;
 
 		@media (min-width: 39rem) {

--- a/src/scss/utilities/_visually-hidden.scss
+++ b/src/scss/utilities/_visually-hidden.scss
@@ -1,8 +1,17 @@
-.util-visually-hidden:not(:focus) {
-	position: absolute;
-	height: 1px;
-	width: 1px;
-	clip-path: inset(50%);
-	overflow: hidden;
-	white-space: nowrap;
+.util-visually-hidden {
+	&:focus {
+		position: absolute;
+		top: 1rem;
+		background-color: var(--brand-background);
+		padding: 0.5rem;
+	}
+
+	&:not(:focus) {
+		position: absolute;
+		height: 1px;
+		width: 1px;
+		clip-path: inset(50%);
+		overflow: hidden;
+		white-space: nowrap;
+	}
 }

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -33,7 +33,8 @@ self.addEventListener('fetch', (event) => {
 	// ignore POST requests etc
 	if (event.request.method !== 'GET') return;
 
-	const { protocol } = new URL(event.request.url);
+	const { hostname, protocol } = new URL(event.request.url);
+	if (hostname === 'localhost') return;
 	if (protocol === 'chrome-extension:') return;
 
 	async function respond() {


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This changes the overview page to not rely on horizontal scrolling, while still making it easy to access the "add" links and see the total for each category. It also adds skip links and sections to help with keyboard/screen reader navigation.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Check the mobile styles to make sure the experience is passable
<!-- Add additional validation steps here -->
