### PR TITLE
feat: add ability to bulk edit savings

### DIFF
--- a/src/components/MonthlyOverview.svelte
+++ b/src/components/MonthlyOverview.svelte
@@ -137,6 +137,11 @@
 		<div>
 			<a href="/savings" class="cmp-form__button">Add Savings</a>
 		</div>
+		{#if savings.length}
+			<p>
+				<a href="/savings/{year}/{month + 1}">Bulk Edit Savings</a>
+			</p>
+		{/if}
 		<a href="#debt" class="util-visually-hidden">Skip to debt</a>
 		{#if savings.length}
 			{#each savings as category}

--- a/src/lib/group-by-category.js
+++ b/src/lib/group-by-category.js
@@ -1,0 +1,50 @@
+const sortByAmount = (a, b) => {
+	if (a.amount > b.amount) {
+		return -1;
+	}
+
+	if (a.amount < b.amount) {
+		return 1;
+	}
+
+	if (a.date > b.date) {
+		return 1;
+	}
+
+	if (a.date < b.date) {
+		return -1;
+	}
+
+	if (a.name > b.name) {
+		return -1;
+	}
+
+	if (a.name < b.name) {
+		return 1;
+	}
+
+	return 0;
+};
+
+export const groupByCategory = (entries) => {
+	const groupedEntries = entries.reduce(
+		(acc, entry) => ({
+			...acc,
+			[entry.category]: {
+				amount: (acc[entry.category]?.amount ?? 0) + entry.amount,
+				entries: [...(acc[entry.category]?.entries ?? []), entry],
+			},
+		}),
+		{}
+	);
+
+	const sortedCategories = Object.entries(groupedEntries)
+		.map(([key, value]) => ({
+			name: key,
+			amount: value.amount,
+			entries: value.entries.sort(sortByAmount),
+		}))
+		.sort(sortByAmount);
+
+	return sortedCategories;
+};

--- a/src/lib/monthly-overview.js
+++ b/src/lib/monthly-overview.js
@@ -1,55 +1,6 @@
-const sortByAmount = (a, b) => {
-	if (a.amount > b.amount) {
-		return -1;
-	}
+import { groupByCategory } from './group-by-category';
 
-	if (a.amount < b.amount) {
-		return 1;
-	}
-
-	if (a.date > b.date) {
-		return 1;
-	}
-
-	if (a.date < b.date) {
-		return -1;
-	}
-
-	if (a.name > b.name) {
-		return -1;
-	}
-
-	if (a.name < b.name) {
-		return 1;
-	}
-
-	return 0;
-};
-
-const groupByCategory = (entries) => {
-	const groupedEntries = entries.reduce(
-		(acc, entry) => ({
-			...acc,
-			[entry.category]: {
-				amount: (acc[entry.category]?.amount ?? 0) + entry.amount,
-				entries: [...(acc[entry.category]?.entries ?? []), entry],
-			},
-		}),
-		{}
-	);
-
-	const sortedCategories = Object.entries(groupedEntries)
-		.map(([key, value]) => ({
-			name: key,
-			amount: value.amount,
-			entries: value.entries.sort(sortByAmount),
-		}))
-		.sort(sortByAmount);
-
-	return sortedCategories;
-};
-
-const getExpenses = async (supabase, currentMonth, nextMonth) => {
+export const getExpenses = async (supabase, currentMonth, nextMonth) => {
 	const { data: expenses } = await supabase
 		.from('expenses')
 		.select('id,date,category,description,amount')
@@ -59,7 +10,7 @@ const getExpenses = async (supabase, currentMonth, nextMonth) => {
 	return groupByCategory(expenses);
 };
 
-const getIncome = async (supabase, currentMonth, nextMonth) => {
+export const getIncome = async (supabase, currentMonth, nextMonth) => {
 	const { data: income } = await supabase
 		.from('income')
 		.select('id,date,category,description,amount')
@@ -69,7 +20,7 @@ const getIncome = async (supabase, currentMonth, nextMonth) => {
 	return groupByCategory(income);
 };
 
-const getSavings = async (supabase, currentMonth, nextMonth) => {
+export const getSavings = async (supabase, currentMonth, nextMonth) => {
 	const { data: savings } = await supabase
 		.from('savings')
 		.select('id,date,category,description,amount')
@@ -79,7 +30,7 @@ const getSavings = async (supabase, currentMonth, nextMonth) => {
 	return groupByCategory(savings);
 };
 
-const getDebt = async (supabase, currentMonth, nextMonth) => {
+export const getDebt = async (supabase, currentMonth, nextMonth) => {
 	const { data: debt } = await supabase
 		.from('debt')
 		.select('id,date,category,description,amount,interest_rate,minimum_payment')

--- a/src/routes/savings/[year]/[month]/+page.server.js
+++ b/src/routes/savings/[year]/[month]/+page.server.js
@@ -1,0 +1,23 @@
+import { getSavings } from '$lib/monthly-overview.js';
+import { gateDynamicPage } from '$lib/gate-dynamic-page.js';
+
+export const load = async ({ params: { year, month }, locals: { supabase } }) => {
+	await gateDynamicPage(supabase);
+
+	// convert string params to numbers, offset month by one so 10 equates to October
+	const numericYear = Number(year);
+	const numericMonth = Number(month) - 1;
+	const formattedDate = new Date(numericYear, numericMonth, 1).toLocaleDateString('en-US', {
+		year: 'numeric',
+		month: 'short',
+	});
+	const currentMonth = new Date(numericYear, numericMonth, 1).toDateString();
+	const nextMonth = new Date(numericYear, numericMonth + 1, 1).toDateString();
+	const savings = await getSavings(supabase, currentMonth, nextMonth);
+
+	return {
+		savings,
+		formattedDate,
+		title: `Savings: ${formattedDate}`,
+	};
+};

--- a/src/routes/savings/[year]/[month]/+page.svelte
+++ b/src/routes/savings/[year]/[month]/+page.svelte
@@ -7,7 +7,7 @@
 <h1>Savings: {data.formattedDate}</h1>
 
 {#if data.savings.length}
-	<form class="cmp-form">
+	<form method="POST" class="cmp-form" aria-label="Bulk edit savings form">
 		{#each data.savings as category}
 			<fieldset class="cmp-form__fieldset">
 				<legend class="cmp-form__legend cmp-form__legend--large">{category.name}</legend>

--- a/src/routes/savings/[year]/[month]/+page.svelte
+++ b/src/routes/savings/[year]/[month]/+page.svelte
@@ -1,0 +1,39 @@
+<script>
+	import { formatCurrency } from '$lib/format-currency';
+
+	export let data;
+</script>
+
+<h1>Savings: {data.formattedDate}</h1>
+
+{#if data.savings.length}
+	<form class="cmp-form">
+		{#each data.savings as category}
+			<fieldset class="cmp-form__fieldset">
+				<legend class="cmp-form__legend cmp-form__legend--large">{category.name}</legend>
+				<div class="cmp-form__bulk-edit">
+					{#each category.entries as entry}
+						<div>
+							<label for={entry.id} class="cmp-form__label">{entry.description}</label>
+							<input
+								id={entry.id}
+								type="text"
+								name={entry.id}
+								class="cmp-form__input cmp-form__input--medium"
+								inputmode="numeric"
+								pattern={'^(\\s{1,})?\\$?\\d{1,3}(,?\\d{3})*(\\.\\d{1,2})?(\\s{1,})?$'}
+								required
+								value={formatCurrency(entry.amount)}
+							/>
+						</div>
+					{/each}
+				</div>
+			</fieldset>
+		{/each}
+		<div>
+			<button type="submit" class="cmp-form__button">Save Changes</button>
+		</div>
+	</form>
+{:else}
+	<p>No savings found.</p>
+{/if}

--- a/src/scss/components/_form.scss
+++ b/src/scss/components/_form.scss
@@ -7,6 +7,10 @@
 	&__legend {
 		display: block;
 		font-weight: 700;
+
+		&--large {
+			font-size: 1.5rem;
+		}
 	}
 
 	&__input {
@@ -104,6 +108,13 @@
 		display: grid;
 		grid-template-columns: repeat(7, max-content);
 		gap: 0.5rem;
+		margin-block-start: 0.5rem;
+	}
+
+	&__bulk-edit {
+		display: flex;
+		flex-flow: row wrap;
+		gap: 1rem;
 		margin-block-start: 0.5rem;
 	}
 }


### PR DESCRIPTION
## Description

<!-- Add description of work done here -->
This adds a page for bulk editing savings to make it easier to update at the beginning of the month. Could probably use some performance tuning, but it's an infrequent enough task that it's low priority.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm run dev` and check for any unexpected changes
4. Click the new "Bulk Edit Savings" link from the overview page (for a current or previous month), confirming the right data shows up on the bulk edit page
5. Edit some values to round, easy-to-remember numbers and submit the form
6. Confirm that the values are updated on the overview page
<!-- Add additional validation steps here -->
